### PR TITLE
Add Specter-DIY Python Lib (#1)

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,229 @@
+# specter-card Python module and CLI
+
+A Python library and command-line tool for interacting with all
+[Specter JavaCard](https://github.com/3rdIteration/specter-javacard) applets.
+
+## Installation
+
+```bash
+cd py/
+pip install -r requirements.txt
+# Optional: install as a package with CLI entry point
+pip install -e .
+```
+
+## Run directly from source (dev / testing)
+
+You can skip the package install step and run the CLI straight from the checked-out
+source tree.  `cli.py` is a thin launcher that delegates to the single canonical
+implementation in `specter_card/cli.py`:
+
+```bash
+cd py/
+pip install -r requirements.txt
+python3 cli.py --help
+```
+
+Example commands:
+
+```bash
+cd py/
+python3 cli.py teapot get
+python3 cli.py --mode simulator memorycard get
+python3 cli.py --pin mysecret memorycard decode-diy
+```
+
+If you install the package, the equivalent commands use the `specter-card`
+entry point instead of `python3 cli.py` — both call the same `specter_card/cli.py`
+implementation.
+
+> **libsecp256k1** – the secure-channel and BlindOracle features require
+> `libsecp256k1`.  The pre-built binaries shipped in
+> `tests/tests/util/prebuilt/` are used automatically as a fallback if the
+> library is not installed system-wide.
+
+## Library usage
+
+```python
+from specter_card import Card, Simulator
+from specter_card import TeapotApplet, SecureApplet, MemoryCardApplet
+from specter_card import BlindOracleApplet, SingleUseKeyApplet
+
+# --- Teapot (no PIN, no secure channel) ---
+conn = Card("B00B5111CA01")
+conn.connect()
+app = TeapotApplet(conn)
+print(app.get())          # b"I am a teapot gimme some tea plz"
+app.store(b"my secret")
+conn.disconnect()
+
+# --- MemoryCard (PIN + secure channel) ---
+conn = Card("B00B5111CB01")
+conn.connect()
+app = MemoryCardApplet(conn)
+sc  = app.open_secure_channel()
+app.set_pin(sc, b"mysecret")
+app.store_data(sc, b"super secret mnemonic")
+sc.close()
+conn.disconnect()
+
+# --- BlindOracle (BIP-32 key management) ---
+conn = Card("B00B5111CE01")
+conn.connect()
+app = BlindOracleApplet(conn)
+sc  = app.open_secure_channel()
+app.unlock(sc, b"mysecret")
+seed = bytes.fromhex("ae361e712e3fe66c8f1d57192d80abe0...")
+xpub = app.set_seed(sc, seed)        # 65 bytes: chain_code + compressed_pubkey
+child_xpub = app.derive_child(sc, "m/44'/0'/0'")
+sig = app.sign(sc, b"\x35" * 32, use_root=False)  # sign with child key
+sc.close()
+conn.disconnect()
+```
+
+## CLI usage
+
+```
+specter-card [--mode {card,simulator}] [--aid AID] [--pin PIN] <applet> <command> [args…]
+```
+
+### Global options
+
+| Option | Description |
+|--------|-------------|
+| `--mode card` | Use a real smartcard via pyscard (default). |
+| `--mode simulator` | Use the local Java simulator. |
+| `--aid <hex>` | Override the applet AID. |
+| `--pin <string>` | PIN to unlock the card before executing the command. |
+| `--port <n>` | Simulator TCP port (default 6666). |
+
+Without `--aid` in `--mode card`, the CLI now tries all compatible applet AIDs for the selected command
+(for example, `secure` commands can run against `secure`, `memorycard`, `blindoracle`, or `singleusekey`).
+
+### `teapot`
+
+| Command | Description |
+|---------|-------------|
+| `teapot get` | Print data stored on the card. |
+| `teapot store <data> [--hex]` | Write up to 254 bytes to the card. |
+
+```bash
+specter-card teapot get
+specter-card teapot store "hello world"
+specter-card teapot store --hex deadbeef
+```
+
+### `discover`
+
+Probe the card for known Specter applet AIDs:
+
+```bash
+specter-card discover
+```
+
+### `secure`
+
+| Command | Description |
+|---------|-------------|
+| `secure get-random` | Print 32 random bytes (hex). |
+| `secure get-pubkey` | Print the card's static public key. |
+| `secure pin-status` | Show PIN status (enabled/disabled, locked/unlocked, attempts left). |
+| `secure set-pin --pin <pin>` | Enable and set a PIN. |
+| `secure unset-pin --pin <pin>` | Permanently disable the PIN. |
+| `secure unlock` | Unlock the card for the current session using global `--pin`. Does **not** remove the PIN. |
+| `secure lock` | Lock the card (requires PIN on next access). |
+| `secure change-pin --old-pin <old> --new-pin <new>` | Change the PIN. |
+| `secure echo <data> [--hex]` | Echo data over the secure channel. |
+| `secure secure-random` | Return 32 random bytes over the secure channel. |
+| `secure probe-modes` | Try `ss`, `es`, and `ee` secure-channel modes and run `secure-random` in each. |
+
+Encrypted commands automatically probe for a working secure-channel mode (trying `ee`, `es`, `ss` in order) and print an `[info]` line showing which mode was selected. To force a specific mode, use `--secure-channel-mode auto|ee|es|ss`.
+
+> **Note — unlock vs unset-pin**
+> `secure unlock --pin <value>` authenticates the card for the *current session only*. The card returns to a locked state after the next power-cycle or an explicit `secure lock` call. The PIN remains set.
+> To *permanently remove* the PIN requirement, use `secure unset-pin --pin <value>`.
+
+> **Note — Specter-DIY cross-compatibility**
+> The PIN is transmitted as `sha256(pin_bytes)` so that the wire payload is always 32 bytes.
+> This matches the convention used by the Specter-DIY firmware, ensuring PINs set on a
+> Specter-DIY device work with this tool and vice versa.
+
+```bash
+specter-card secure get-random
+specter-card secure get-random   # also works if only a derived secure applet is installed
+specter-card secure get-pubkey
+specter-card secure set-pin --pin mysecret
+specter-card --pin mysecret secure pin-status
+specter-card --secure-channel-mode ee secure pin-status
+specter-card --pin mysecret secure unlock   # unlock for this session only; PIN stays set
+specter-card --pin mysecret secure lock
+specter-card --pin mysecret secure unset-pin --pin mysecret   # permanently remove the PIN
+specter-card --pin mysecret secure change-pin --old-pin mysecret --new-pin newpin
+specter-card secure probe-modes
+```
+
+### `memorycard`
+
+| Command | Description |
+|---------|-------------|
+| `memorycard get [--device-secret <hex>]` | Read raw secret data as hex, then attempt Specter-DIY decode. |
+| `memorycard store <data> [--hex]` | Write up to 220 bytes (PIN-protected). |
+
+```bash
+specter-card --pin mysecret memorycard get
+specter-card --pin mysecret memorycard get --device-secret <32-byte-hex>
+specter-card --pin mysecret memorycard store "my mnemonic phrase"
+specter-card --pin mysecret memorycard store --hex deadbeef
+```
+
+### `blindoracle`
+
+| Command | Description |
+|---------|-------------|
+| `blindoracle set-seed <seed> [--hex]` | Load a BIP-32 seed (16-64 bytes). |
+| `blindoracle set-xprv <xprv_hex>` | Load a root key directly (65 bytes). |
+| `blindoracle gen-key` | Generate a random root key (no backup!). |
+| `blindoracle get-root-xpub` | Print the root xpub. |
+| `blindoracle derive <path> [--from root\|child]` | Derive and cache a child key. |
+| `blindoracle get-child` | Print the cached child xpub. |
+| `blindoracle sign --hash <hex> [--key root\|child]` | Sign a 32-byte hash. |
+| `blindoracle derive-sign --hash <hex> <path> [--from root\|child]` | Derive + sign (temporary key). |
+
+xpub format: `chain_code (32 bytes) + compressed_pubkey (33 bytes)` = 65 bytes total.
+
+```bash
+specter-card --pin mysecret blindoracle set-seed --hex ae361e...
+specter-card --pin mysecret blindoracle get-root-xpub
+specter-card --pin mysecret blindoracle derive "m/44'/0'/0'"
+specter-card --pin mysecret blindoracle sign --hash $(python3 -c "print('35'*32)") --key child
+specter-card --pin mysecret blindoracle derive-sign --hash $(python3 -c "print('35'*32)") "m/0/1"
+```
+
+### `singleusekey`
+
+| Command | Description |
+|---------|-------------|
+| `singleusekey generate [--secure]` | Generate a new key; returns the pubkey. |
+| `singleusekey get-pubkey [--secure]` | Return the current pubkey. |
+| `singleusekey sign --hash <hex> [--secure]` | Sign a 32-byte hash (key is replaced after). |
+
+```bash
+specter-card singleusekey generate
+specter-card singleusekey get-pubkey
+specter-card singleusekey sign --hash 3535...3535
+# Using the secure channel:
+specter-card --pin mysecret singleusekey sign --hash 3535...3535 --secure
+```
+
+## Using the simulator
+
+Start the simulator first (or pass `--mode simulator` to have the CLI start it automatically):
+
+```bash
+# Manually start the simulator
+python run_sim.py Teapot
+
+# Then use the CLI against it
+specter-card --mode simulator teapot get
+specter-card --mode simulator --pin mysecret memorycard get
+```

--- a/py/cli.py
+++ b/py/cli.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Thin launcher – the full CLI implementation lives in specter_card/cli.py."""
+import os
+import sys
+
+# Allow running directly from the py/ directory without installing the package.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from specter_card.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    main()

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,0 +1,2 @@
+cryptography
+pyscard

--- a/py/setup.py
+++ b/py/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="specter-card",
+    version="0.1.0",
+    description="Python library and CLI for Specter JavaCard applets",
+    packages=find_packages(),
+    python_requires=">=3.7",
+    install_requires=[
+        "cryptography",
+        "pyscard",
+    ],
+    entry_points={
+        "console_scripts": [
+            "specter-card=specter_card.cli:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/py/specter_card/__init__.py
+++ b/py/specter_card/__init__.py
@@ -1,0 +1,22 @@
+"""specter_card – Python library for the Specter JavaCard applets."""
+
+from .connection import Card, Simulator, ISOException
+from .securechannel import SecureChannel, SecureError
+from .applets.teapot import TeapotApplet
+from .applets.secure import SecureApplet
+from .applets.memorycard import MemoryCardApplet
+from .applets.blindoracle import BlindOracleApplet
+from .applets.singleusekey import SingleUseKeyApplet
+
+__all__ = [
+    "Card",
+    "Simulator",
+    "ISOException",
+    "SecureChannel",
+    "SecureError",
+    "TeapotApplet",
+    "SecureApplet",
+    "MemoryCardApplet",
+    "BlindOracleApplet",
+    "SingleUseKeyApplet",
+]

--- a/py/specter_card/applets/__init__.py
+++ b/py/specter_card/applets/__init__.py
@@ -1,0 +1,15 @@
+"""specter_card.applets sub-package."""
+
+from .teapot import TeapotApplet
+from .secure import SecureApplet
+from .memorycard import MemoryCardApplet
+from .blindoracle import BlindOracleApplet
+from .singleusekey import SingleUseKeyApplet
+
+__all__ = [
+    "TeapotApplet",
+    "SecureApplet",
+    "MemoryCardApplet",
+    "BlindOracleApplet",
+    "SingleUseKeyApplet",
+]

--- a/py/specter_card/applets/blindoracle.py
+++ b/py/specter_card/applets/blindoracle.py
@@ -1,0 +1,211 @@
+"""
+BlindOracleApplet – BIP-32 HD key storage, derivation, and signing.
+
+All commands are PIN-protected and transmitted over a secure channel.
+The card stores a root key derived from a seed or imported as xprv,
+and can derive child keys and sign 32-byte message hashes.
+
+xpub format used by the card: ``<chain_code (32 bytes)><compressed_pubkey (33 bytes)>``
+"""
+import re
+from .secure import SecureApplet
+from ..securechannel import SecureChannel
+
+AID      = "B00B5111CE01"
+APPLET   = "toys.BlindOracleApplet"
+CLASSDIR = "BlindOracle"
+
+# Secure-channel command bytes
+_CMD_KEY_MGMT  = 0x10
+_CMD_KEY_OPS   = 0x11
+
+_SUBCMD_SET_SEED    = 0x00
+_SUBCMD_SET_ROOT    = 0x01
+_SUBCMD_GEN_RANDOM  = 0x7D
+
+_SUBCMD_GET_ROOT   = 0x00
+_SUBCMD_DERIVE     = 0x01
+_SUBCMD_GET_CHILD  = 0x02
+_SUBCMD_SIGN       = 0x03
+_SUBCMD_DERIVE_SIGN = 0x04
+
+KEYID_ROOT  = 0x00
+KEYID_CHILD = 0x01
+
+
+def _parse_path(path: str) -> bytes:
+    """
+    Convert a BIP-32 derivation path string to packed 4-byte big-endian indexes.
+
+    Accepted formats::
+
+        "m/44'/0'/1'/0/55"   apostrophe for hardened
+        "44h/0h/1h/0/55"     'h' suffix for hardened
+        "44'/0'/1'/0/55"     no leading 'm/'
+
+    Parameters
+    ----------
+    path : str
+        Human-readable BIP-32 path.
+
+    Returns
+    -------
+    bytes
+        Sequence of 4-byte big-endian encoded derivation indexes.
+    """
+    path = path.strip().lstrip("m").lstrip("/")
+    if not path:
+        return b""
+    parts = path.split("/")
+    result = b""
+    for part in parts:
+        part = part.strip()
+        hardened = part.endswith("'") or part.lower().endswith("h")
+        index = int(re.sub(r"[h'H]$", "", part))
+        if hardened:
+            index += 0x80000000
+        result += index.to_bytes(4, "big")
+    return result
+
+
+class BlindOracleApplet(SecureApplet):
+    """
+    High-level interface to the BlindOracleApplet.
+
+    Parameters
+    ----------
+    connection :
+        A connected :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    """
+
+    AID      = AID
+    APPLET   = APPLET
+    CLASSDIR = CLASSDIR
+
+    # ------------------------------------------------------------------
+    # Key management
+    # ------------------------------------------------------------------
+    def set_seed(self, sc: SecureChannel, seed: bytes) -> bytes:
+        """
+        Derive a BIP-32 root key from *seed* (16–64 bytes) and store it on the card.
+
+        Returns the root xpub as ``chain_code (32) + compressed_pubkey (33)``.
+        """
+        if not (16 <= len(seed) <= 64):
+            raise ValueError("Seed must be between 16 and 64 bytes")
+        return sc.request(bytes([_CMD_KEY_MGMT, _SUBCMD_SET_SEED]) + seed)
+
+    def set_root_key(self, sc: SecureChannel, root_key: bytes) -> bytes:
+        """
+        Import an existing xprv directly.
+
+        *root_key* must be exactly 65 bytes: ``chain_code (32) + 0x00 + private_key (32)``.
+
+        Returns the root xpub as ``chain_code (32) + compressed_pubkey (33)``.
+        """
+        if len(root_key) != 65:
+            raise ValueError("root_key must be 65 bytes: chain_code + 0x00 + privkey")
+        return sc.request(bytes([_CMD_KEY_MGMT, _SUBCMD_SET_ROOT]) + root_key)
+
+    def generate_random_key(self, sc: SecureChannel) -> bytes:
+        """
+        Generate a random root key on the card (cannot be backed up).
+
+        Returns the root xpub as ``chain_code (32) + compressed_pubkey (33)``.
+        """
+        return sc.request(bytes([_CMD_KEY_MGMT, _SUBCMD_GEN_RANDOM]))
+
+    # ------------------------------------------------------------------
+    # Key derivation and retrieval
+    # ------------------------------------------------------------------
+    def get_root_xpub(self, sc: SecureChannel) -> bytes:
+        """
+        Return the root xpub: ``chain_code (32) + compressed_pubkey (33)``.
+        """
+        return sc.request(bytes([_CMD_KEY_OPS, _SUBCMD_GET_ROOT]))
+
+    def derive_child(self, sc: SecureChannel, path: str, from_root: bool = True) -> bytes:
+        """
+        Derive a child key and cache it on the card.
+
+        Parameters
+        ----------
+        path : str
+            BIP-32 path (e.g. ``"m/44'/0'/1'"``).
+        from_root : bool
+            If ``True`` (default) derive from the root key; otherwise continue
+            from the previously derived child.
+
+        Returns
+        -------
+        bytes
+            Derived child xpub: ``chain_code (32) + compressed_pubkey (33)``.
+        """
+        keyid = KEYID_ROOT if from_root else KEYID_CHILD
+        bpath = _parse_path(path)
+        return sc.request(bytes([_CMD_KEY_OPS, _SUBCMD_DERIVE, keyid]) + bpath)
+
+    def get_current_child(self, sc: SecureChannel) -> bytes:
+        """
+        Return the currently cached child xpub (from the last :meth:`derive_child`).
+        """
+        return sc.request(bytes([_CMD_KEY_OPS, _SUBCMD_GET_CHILD]))
+
+    # ------------------------------------------------------------------
+    # Signing
+    # ------------------------------------------------------------------
+    def sign(self, sc: SecureChannel, msg_hash: bytes, use_root: bool = True) -> bytes:
+        """
+        Sign a 32-byte message hash.
+
+        Parameters
+        ----------
+        msg_hash : bytes
+            The 32-byte message hash to sign.
+        use_root : bool
+            If ``True`` (default) sign with the root key; otherwise sign with the
+            currently cached child key.
+
+        Returns
+        -------
+        bytes
+            DER-encoded ECDSA signature.
+        """
+        if len(msg_hash) != 32:
+            raise ValueError("msg_hash must be exactly 32 bytes")
+        keyid = KEYID_ROOT if use_root else KEYID_CHILD
+        return sc.request(bytes([_CMD_KEY_OPS, _SUBCMD_SIGN]) + msg_hash + bytes([keyid]))
+
+    def derive_and_sign(
+        self,
+        sc: SecureChannel,
+        msg_hash: bytes,
+        path: str,
+        from_root: bool = True,
+    ) -> bytes:
+        """
+        Derive a temporary key and sign *msg_hash* without changing the cached child.
+
+        Parameters
+        ----------
+        msg_hash : bytes
+            The 32-byte message hash to sign.
+        path : str
+            BIP-32 path relative to the chosen key slot.
+        from_root : bool
+            If ``True`` (default) derive from the root key; otherwise continue
+            from the currently cached child.
+
+        Returns
+        -------
+        bytes
+            DER-encoded ECDSA signature.
+        """
+        if len(msg_hash) != 32:
+            raise ValueError("msg_hash must be exactly 32 bytes")
+        keyid = KEYID_ROOT if from_root else KEYID_CHILD
+        bpath = _parse_path(path)
+        return sc.request(
+            bytes([_CMD_KEY_OPS, _SUBCMD_DERIVE_SIGN]) + msg_hash + bytes([keyid]) + bpath
+        )

--- a/py/specter_card/applets/memorycard.py
+++ b/py/specter_card/applets/memorycard.py
@@ -1,0 +1,92 @@
+"""
+MemoryCardApplet – secure storage for up to 220 bytes (seed / mnemonic / xprv).
+
+Extends SecureApplet with get_data / store_data commands, both PIN-protected.
+"""
+from .secure import SecureApplet
+from ..securechannel import SecureChannel
+from ..diy_crypt import parse_sdiy_blob, DecryptionError  # noqa: F401 – re-exported
+
+AID      = "B00B5111CB01"
+APPLET   = "toys.MemoryCardApplet"
+CLASSDIR = "MemoryCard"
+
+_CMD_MEMORY    = 0x05
+_SUBCMD_GET    = 0x00
+_SUBCMD_STORE  = 0x01
+
+MAX_DATA_LEN = 220
+
+
+class MemoryCardApplet(SecureApplet):
+    """
+    High-level interface to the MemoryCardApplet.
+
+    All data commands require an open, unlocked secure channel.
+
+    Parameters
+    ----------
+    connection :
+        A connected :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    """
+
+    AID      = AID
+    APPLET   = APPLET
+    CLASSDIR = CLASSDIR
+
+    # ------------------------------------------------------------------
+    def get_data(self, sc: SecureChannel) -> bytes:
+        """
+        Return the secret data stored on the card.
+
+        The card must be unlocked (PIN-checked) before calling this.
+        """
+        return sc.request(bytes([_CMD_MEMORY, _SUBCMD_GET]))
+
+    def decode_diy_data(self, sc: SecureChannel, device_secret: bytes = None) -> dict:
+        """
+        Retrieve and decrypt a Specter-DIY blob from the card.
+
+        Reads the raw bytes via :meth:`get_data` and passes them to
+        :func:`~specter_card.diy_crypt.parse_sdiy_blob`.
+
+        Parameters
+        ----------
+        sc : SecureChannel
+            An open, unlocked secure channel.
+        device_secret : bytes, optional
+            32-byte internal secret from the Specter-DIY device's MCU flash.
+            Required when the stored blob is encrypted; not needed for
+            plain-text blobs.
+
+        Returns
+        -------
+        dict
+            Keys:
+
+            * ``"entropy"``   – :class:`bytes`: raw BIP-39 entropy
+            * ``"encrypted"`` – :class:`bool`: whether the blob was encrypted
+            * ``"mnemonic"``  – :class:`str` or ``None``: BIP-39 mnemonic
+              (populated only when the ``embit`` package is available)
+
+        Raises
+        ------
+        DecryptionError
+            If decryption fails or the blob is not a valid Specter-DIY blob.
+        """
+        raw = self.get_data(sc)
+        return parse_sdiy_blob(raw, device_secret=device_secret)
+
+    def store_data(self, sc: SecureChannel, data: bytes) -> bytes:
+        """
+        Persist *data* on the card (up to 220 bytes) and return the stored value.
+
+        Parameters
+        ----------
+        data : bytes
+            Payload to store.  Maximum 220 bytes.
+        """
+        if len(data) > MAX_DATA_LEN:
+            raise ValueError(f"Maximum data size is {MAX_DATA_LEN} bytes")
+        return sc.request(bytes([_CMD_MEMORY, _SUBCMD_STORE]) + data)

--- a/py/specter_card/applets/secure.py
+++ b/py/specter_card/applets/secure.py
@@ -1,0 +1,160 @@
+"""
+SecureApplet – base class for all PIN-protected applets.
+
+Provides:
+  - Plaintext get_random / get_pubkey APDUs
+  - Secure-channel helpers (open_secure_channel, echo, secure_random)
+  - PIN management (status, set, unset, unlock, lock, change)
+"""
+import hashlib
+
+from ..connection import ISOException
+from ..securechannel import SecureChannel, SecureError
+
+_CLA           = 0xB0
+_INS_RANDOM    = 0xB1
+_INS_PUBKEY    = 0xB2
+
+# Secure-channel sub-commands
+_CMD_ECHO        = 0x00
+_CMD_RANDOM      = 0x01
+_CMD_PIN         = 0x03
+
+_SUBCMD_PIN_STATUS  = 0x00
+_SUBCMD_PIN_UNLOCK  = 0x01
+_SUBCMD_PIN_LOCK    = 0x02
+_SUBCMD_PIN_CHANGE  = 0x03
+_SUBCMD_PIN_SET     = 0x04
+_SUBCMD_PIN_UNSET   = 0x05
+
+_encode = lambda d: bytes([len(d)]) + d
+
+# PIN bytes are always SHA-256 hashed before transmission so that:
+#   1. The wire payload is a constant 32 bytes regardless of PIN length.
+#   2. Cross-device compatibility with Specter-DIY is maintained (its firmware
+#      applies the same sha256(pin) transform before every PIN APDU).
+_hash_pin = lambda pin: hashlib.sha256(pin).digest()
+
+AID      = "B00B5111FF01"
+APPLET   = "toys.SecureApplet"
+CLASSDIR = "Secure"
+
+# PIN status third-byte values
+PIN_DISABLED  = 0x00
+PIN_LOCKED    = 0x01
+PIN_UNLOCKED  = 0x02
+PIN_BRICKED   = 0x03
+
+
+class SecureApplet:
+    """
+    High-level interface to the SecureApplet (and subclasses).
+
+    Parameters
+    ----------
+    connection :
+        A connected :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    """
+
+    AID      = AID
+    APPLET   = APPLET
+    CLASSDIR = CLASSDIR
+
+    def __init__(self, connection):
+        self.conn = connection
+
+    # ------------------------------------------------------------------
+    # Plaintext APDUs
+    # ------------------------------------------------------------------
+    def get_random(self) -> bytes:
+        """Return 32 random bytes from the card (unauthenticated)."""
+        return self.conn.request(bytes([_CLA, _INS_RANDOM, 0x00, 0x00]))
+
+    def get_pubkey(self) -> bytes:
+        """
+        Return the card's static 65-byte uncompressed public key.
+
+        This key identifies the card and is used to open a secure channel.
+        """
+        return self.conn.request(bytes([_CLA, _INS_PUBKEY, 0x00, 0x00]))
+
+    # ------------------------------------------------------------------
+    # Secure channel helpers
+    # ------------------------------------------------------------------
+    def open_secure_channel(self, mode: str = "es") -> SecureChannel:
+        """
+        Open and return a :class:`~specter_card.securechannel.SecureChannel`.
+
+        Parameters
+        ----------
+        mode : str
+            ``"ss"``, ``"es"`` (default), or ``"ee"``.
+        """
+        sc = SecureChannel(self.conn, mode=mode)
+        sc.open()
+        return sc
+
+    def echo(self, sc: SecureChannel, data: bytes) -> bytes:
+        """Echo *data* through the secure channel (useful for testing)."""
+        return sc.request(bytes([_CMD_ECHO, 0x00]) + data)
+
+    def secure_random(self, sc: SecureChannel) -> bytes:
+        """Return 32 random bytes over the secure channel."""
+        return sc.request(bytes([_CMD_RANDOM, 0x00]))
+
+    # ------------------------------------------------------------------
+    # PIN management (all over secure channel)
+    # ------------------------------------------------------------------
+    def pin_status(self, sc: SecureChannel) -> dict:
+        """
+        Return a dict with PIN status information.
+
+        Keys:
+          - ``attempts_left`` – remaining unlock attempts
+          - ``max_attempts``  – total allowed attempts (usually 10)
+          - ``status``        – ``"disabled"``, ``"locked"``, ``"unlocked"``, or ``"bricked"``
+        """
+        raw = sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_STATUS]))
+        left, total, state = raw[0], raw[1], raw[2]
+        state_map = {
+            PIN_DISABLED: "disabled",
+            PIN_LOCKED:   "locked",
+            PIN_UNLOCKED: "unlocked",
+            PIN_BRICKED:  "bricked",
+        }
+        return {
+            "attempts_left": left,
+            "max_attempts":  total,
+            "status":        state_map.get(state, f"unknown(0x{state:02x})"),
+        }
+
+    def set_pin(self, sc: SecureChannel, pin: bytes) -> None:
+        """
+        Enable PIN and set it to *pin* (up to 32 bytes).
+
+        Raises :exc:`~specter_card.securechannel.SecureError` with code ``0506``
+        if a PIN is already set.
+        """
+        sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_SET]) + _hash_pin(pin))
+
+    def unset_pin(self, sc: SecureChannel, pin: bytes) -> None:
+        """Disable PIN using the current *pin* value."""
+        sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_UNSET]) + _hash_pin(pin))
+
+    def unlock(self, sc: SecureChannel, pin: bytes) -> None:
+        """
+        Unlock the card using *pin*.
+
+        Raises :exc:`~specter_card.securechannel.SecureError` with code ``0502``
+        on wrong PIN or ``0503`` if no attempts remain.
+        """
+        sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_UNLOCK]) + _hash_pin(pin))
+
+    def lock(self, sc: SecureChannel) -> None:
+        """Lock the card."""
+        sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_LOCK]))
+
+    def change_pin(self, sc: SecureChannel, old_pin: bytes, new_pin: bytes) -> None:
+        """Change PIN from *old_pin* to *new_pin*."""
+        sc.request(bytes([_CMD_PIN, _SUBCMD_PIN_CHANGE]) + _encode(_hash_pin(old_pin)) + _encode(_hash_pin(new_pin)))

--- a/py/specter_card/applets/singleusekey.py
+++ b/py/specter_card/applets/singleusekey.py
@@ -1,0 +1,117 @@
+"""
+SingleUseKeyApplet – generates a single-use key and can sign exactly once per key.
+
+Supports both plaintext APDUs (no secure channel) and secure-channel commands.
+"""
+from .secure import SecureApplet
+from ..securechannel import SecureChannel
+
+AID      = "B00B5111CD01"
+APPLET   = "toys.SingleUseKeyApplet"
+CLASSDIR = "SingleUseKey"
+
+# Plaintext APDU bytes
+_CLA_PLAIN         = 0xB0
+_INS_PLAIN         = 0xA0
+_P1_GENERATE       = 0x00
+_P1_GET_PUBKEY     = 0x01
+_P1_SIGN           = 0x02
+
+# Secure channel command bytes
+_CMD_SINGLE_USE_KEY        = 0x20
+_SUBCMD_GENERATE           = 0x00
+_SUBCMD_GET_PUBKEY         = 0x01
+_SUBCMD_SIGN               = 0x02
+
+
+class SingleUseKeyApplet(SecureApplet):
+    """
+    High-level interface to the SingleUseKeyApplet.
+
+    Each key can be used to sign **only one** message hash.  After signing,
+    the key is overwritten with a new random key automatically.
+
+    Both plaintext (no secure channel) and secure-channel variants are provided
+    for every operation.  Prefer the secure-channel variants to protect against
+    man-in-the-middle attacks.
+
+    Parameters
+    ----------
+    connection :
+        A connected :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    """
+
+    AID      = AID
+    APPLET   = APPLET
+    CLASSDIR = CLASSDIR
+
+    # ------------------------------------------------------------------
+    # Plaintext variants
+    # ------------------------------------------------------------------
+    def generate(self) -> bytes:
+        """
+        Generate a new single-use key (plaintext).
+
+        Returns the corresponding compressed public key (33 bytes).
+        """
+        return self.conn.request(bytes([_CLA_PLAIN, _INS_PLAIN, _P1_GENERATE, 0x00]))
+
+    def get_pubkey(self) -> bytes:
+        """
+        Return the current single-use public key (plaintext, compressed, 33 bytes).
+        """
+        return self.conn.request(bytes([_CLA_PLAIN, _INS_PLAIN, _P1_GET_PUBKEY, 0x00]))
+
+    def sign(self, msg_hash: bytes) -> bytes:
+        """
+        Sign *msg_hash* with the current single-use key (plaintext).
+
+        After signing, the key is automatically replaced with a new random key.
+
+        Parameters
+        ----------
+        msg_hash : bytes
+            Exactly 32 bytes.
+
+        Returns
+        -------
+        bytes
+            DER-encoded ECDSA signature.
+        """
+        if len(msg_hash) != 32:
+            raise ValueError("msg_hash must be exactly 32 bytes")
+        return self.conn.request(
+            bytes([_CLA_PLAIN, _INS_PLAIN, _P1_SIGN, 0x00, len(msg_hash)]) + msg_hash
+        )
+
+    # ------------------------------------------------------------------
+    # Secure-channel variants (PIN-protected)
+    # ------------------------------------------------------------------
+    def sc_generate(self, sc: SecureChannel) -> bytes:
+        """Generate a new single-use key over the secure channel."""
+        return sc.request(bytes([_CMD_SINGLE_USE_KEY, _SUBCMD_GENERATE]))
+
+    def sc_get_pubkey(self, sc: SecureChannel) -> bytes:
+        """Return the current single-use public key over the secure channel."""
+        return sc.request(bytes([_CMD_SINGLE_USE_KEY, _SUBCMD_GET_PUBKEY]))
+
+    def sc_sign(self, sc: SecureChannel, msg_hash: bytes) -> bytes:
+        """
+        Sign *msg_hash* over the secure channel.
+
+        After signing, the key is automatically replaced with a new random key.
+
+        Parameters
+        ----------
+        msg_hash : bytes
+            Exactly 32 bytes.
+
+        Returns
+        -------
+        bytes
+            DER-encoded ECDSA signature.
+        """
+        if len(msg_hash) != 32:
+            raise ValueError("msg_hash must be exactly 32 bytes")
+        return sc.request(bytes([_CMD_SINGLE_USE_KEY, _SUBCMD_SIGN]) + msg_hash)

--- a/py/specter_card/applets/teapot.py
+++ b/py/specter_card/applets/teapot.py
@@ -1,0 +1,56 @@
+"""
+TeapotApplet – simple plaintext key/value store (no PIN, no secure channel).
+"""
+from ..connection import ISOException
+
+# APDU constants
+_CLA   = 0xB0
+_INS_GET   = 0xA1
+_INS_STORE = 0xA2
+
+AID      = "B00B5111CA01"
+APPLET   = "toys.TeapotApplet"
+CLASSDIR = "Teapot"
+
+
+class TeapotApplet:
+    """
+    High-level interface to the TeapotApplet.
+
+    Parameters
+    ----------
+    connection :
+        A connected :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    """
+
+    AID      = AID
+    APPLET   = APPLET
+    CLASSDIR = CLASSDIR
+
+    def __init__(self, connection):
+        self.conn = connection
+
+    # ------------------------------------------------------------------
+    def get(self) -> bytes:
+        """Return the bytes currently stored on the card."""
+        return self.conn.request(bytes([_CLA, _INS_GET, 0x00, 0x00]))
+
+    def store(self, data: bytes) -> bytes:
+        """
+        Write *data* (up to 254 bytes) to the card and return the stored value.
+
+        Parameters
+        ----------
+        data : bytes
+            Payload to persist.  Maximum 254 bytes.
+
+        Raises
+        ------
+        ISOException
+            If the card returns SW 0x6700 (wrong length) or another error.
+        """
+        if len(data) > 254:
+            raise ValueError("Maximum storage is 254 bytes")
+        payload = bytes([_CLA, _INS_STORE, 0x00, 0x00, len(data)]) + data
+        return self.conn.request(payload)

--- a/py/specter_card/cli.py
+++ b/py/specter_card/cli.py
@@ -1,0 +1,996 @@
+#!/usr/bin/env python3
+"""
+specter-card CLI
+================
+
+Command-line interface for all Specter JavaCard applets.
+
+Usage
+-----
+::
+
+    specter-card [--mode {card,simulator}] [--aid AID] [--pin PIN]
+                 [--secure-channel-mode {auto,ee,es,ss}] <applet> <command> [args…]
+
+Applets
+-------
+``discover``      Probe for installed Specter applets by trying known AIDs.
+``teapot``        Simple plaintext key/value store.
+``secure``        Base SecureApplet – random, pubkey, PIN management, mode probing.
+``memorycard``    Secure byte-string storage (PIN-protected).
+``blindoracle``   BIP-32 HD key storage, derivation and signing.
+``singleusekey``  Single-use key generation and signing.
+
+Run ``specter-card <applet> --help`` for per-applet options.
+
+Examples
+--------
+::
+
+    # Print the teapot's stored phrase
+    specter-card teapot get
+
+    # Store a custom phrase
+    specter-card teapot store "hello world"
+
+    # Get 32 random bytes from the card (hex)
+    specter-card secure get-random
+
+    # Set a PIN (auto-selects a working secure-channel mode, preferring ee)
+    specter-card secure set-pin --pin mysecret
+
+    # Force a specific secure-channel mode
+    specter-card --secure-channel-mode es secure pin-status
+
+    # Store secret data in MemoryCard after unlocking with PIN
+    specter-card --pin mysecret memorycard store --hex deadbeef
+
+    # Decrypt a Specter-DIY blob (unencrypted)
+    specter-card --pin mysecret memorycard decode-diy
+
+    # Decrypt a Specter-DIY blob (encrypted – supply the device's MCU secret)
+    specter-card --pin mysecret memorycard decode-diy --device-secret <32-byte-hex>
+
+    # Import a BIP-32 seed and sign a hash
+    specter-card --pin mysecret blindoracle set-seed --hex ae361e...
+    specter-card --pin mysecret blindoracle sign --hash 3132...20 --key root
+
+    # Generate a single-use key
+    specter-card singleusekey generate
+"""
+import argparse
+import sys
+import os
+
+from .connection import Card, Simulator, ISOException
+from .securechannel import SecureChannel, SecureError, SUPPORTED_SECURE_CHANNEL_MODES
+from .applets.teapot import TeapotApplet
+from .applets.secure import SecureApplet
+from .applets.memorycard import MemoryCardApplet, DecryptionError
+from .applets.blindoracle import BlindOracleApplet
+from .applets.singleusekey import SingleUseKeyApplet
+from .diy_crypt import parse_sdiy_blob
+
+# ---------------------------------------------------------------------------
+# Applet metadata (aid, applet class name, classdir)
+# ---------------------------------------------------------------------------
+APPLET_META = {
+    "teapot":       (TeapotApplet.AID,       TeapotApplet.APPLET,       TeapotApplet.CLASSDIR),
+    "secure":       (SecureApplet.AID,       SecureApplet.APPLET,       SecureApplet.CLASSDIR),
+    "memorycard":   (MemoryCardApplet.AID,   MemoryCardApplet.APPLET,   MemoryCardApplet.CLASSDIR),
+    "blindoracle":  (BlindOracleApplet.AID,  BlindOracleApplet.APPLET,  BlindOracleApplet.CLASSDIR),
+    "singleusekey": (SingleUseKeyApplet.AID, SingleUseKeyApplet.APPLET, SingleUseKeyApplet.CLASSDIR),
+}
+
+APPLET_CLASSES = {
+    "teapot":       TeapotApplet,
+    "secure":       SecureApplet,
+    "memorycard":   MemoryCardApplet,
+    "blindoracle":  BlindOracleApplet,
+    "singleusekey": SingleUseKeyApplet,
+}
+
+AUTO_SECURE_CHANNEL_MODE = "auto"
+AUTO_SECURE_CHANNEL_MODE_PRIORITY = ("ee", "es", "ss")
+
+# ---------------------------------------------------------------------------
+# Error code descriptions
+# ---------------------------------------------------------------------------
+
+# SecureError codes are applet-level status words returned inside the
+# encrypted channel (defined in SecureApplet.java).
+_SECURE_ERROR_DESCRIPTIONS = {
+    "0403": "invalid length",
+    "0404": "invalid command",
+    "0405": "invalid sub-command",
+    "0406": "not implemented",
+    "0501": "card locked",
+    "0502": "wrong PIN",
+    "0503": "no PIN attempts remaining",
+    "0504": "already unlocked",
+    "0505": "PIN not set",
+    "0506": "PIN already set",
+}
+
+# ISOException codes are standard ISO 7816-4 status words returned at the
+# transport level (outside the secure channel).
+_ISO_ERROR_DESCRIPTIONS = {
+    "6700": "wrong length",
+    "6900": "command not allowed",
+    "6982": "security status not satisfied",
+    "6984": "reference data not usable",
+    "6985": "conditions of use not satisfied",
+    "6a80": "incorrect data in command field",
+    "6a82": "file or application not found",
+    "6a86": "incorrect parameters P1-P2",
+    "6d00": "instruction not supported",
+    "6e00": "class not supported",
+    "6f00": "unknown error",
+}
+
+
+def _fmt_error(code: str, descriptions: dict) -> str:
+    """Return 'XXXX (description)' if a description is known, else just 'XXXX'."""
+    desc = descriptions.get(code.lower())
+    return f"{code} ({desc})" if desc else code
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bytes_arg(value: str, hex_flag: bool) -> bytes:
+    """Return bytes from *value*, interpreting it as hex when *hex_flag* is set."""
+    if hex_flag:
+        try:
+            return bytes.fromhex(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"Invalid hex string: {value!r}")
+    return value.encode()
+
+
+def _print_bytes(data: bytes, label: str = None):
+    """Pretty-print *data* as hex with an optional *label*."""
+    if label:
+        print(f"{label}: {data.hex()}")
+    else:
+        print(data.hex())
+
+
+def _parse_device_secret_hex(device_secret_hex: str):
+    """Parse optional --device-secret hex into bytes."""
+    if not device_secret_hex:
+        return None
+    try:
+        return bytes.fromhex(device_secret_hex)
+    except ValueError:
+        print("[error] --device-secret must be a hex string", file=sys.stderr)
+        sys.exit(1)
+
+
+def _connect_once(args, applet_name: str, aid: str = None):
+    """Connect once to a specific applet entry (or explicit AID)."""
+    meta = APPLET_META[applet_name]
+    aid = aid if aid else meta[0]
+    if args.mode == "simulator":
+        conn = Simulator(aid, meta[1], meta[2], port=getattr(args, "port", 6666))
+    else:
+        conn = Card(aid)
+    conn.connect()
+    return conn
+
+
+def _compatible_applets(applet_name: str):
+    """Return applet names that can serve commands for *applet_name*."""
+    base_cls = APPLET_CLASSES[applet_name]
+    derived = [
+        name
+        for name, cls in APPLET_CLASSES.items()
+        if name != applet_name and issubclass(cls, base_cls)
+    ]
+    return [applet_name] + derived
+
+
+def _make_connection(args, applet_name: str):
+    """
+    Build and connect the appropriate connection object.
+
+    On card mode without --aid override, tries all compatible applet AIDs in order.
+    """
+    if args.aid:
+        return _connect_once(args, applet_name, aid=args.aid), applet_name
+    if args.mode == "simulator":
+        return _connect_once(args, applet_name), applet_name
+
+    last_iso = None
+    candidates = _compatible_applets(applet_name)
+    for candidate in candidates:
+        try:
+            conn = _connect_once(args, candidate)
+            if candidate != applet_name:
+                print(
+                    f"[info] {applet_name} command matched installed '{candidate}' applet "
+                    f"(AID {APPLET_META[candidate][0]})."
+                )
+            return conn, candidate
+        except ISOException as e:
+            if e.code == "6a82":
+                last_iso = e
+                continue
+            raise
+
+    if last_iso is not None:
+        raise last_iso
+    raise RuntimeError(f"Could not connect to any compatible applet for '{applet_name}'")
+
+
+def _secure_mode_candidates(requested_mode, cached_mode=None):
+    """Return secure-channel modes to try in priority order."""
+    if requested_mode != AUTO_SECURE_CHANNEL_MODE:
+        return (requested_mode,)
+    candidates = []
+    if cached_mode in AUTO_SECURE_CHANNEL_MODE_PRIORITY:
+        candidates.append(cached_mode)
+    for mode in AUTO_SECURE_CHANNEL_MODE_PRIORITY:
+        if mode not in candidates:
+            candidates.append(mode)
+    return tuple(candidates)
+
+
+def _open_sc(conn, mode=AUTO_SECURE_CHANNEL_MODE):
+    """Open a secure channel, auto-probing secure-random when mode selection is automatic."""
+    cached_mode = getattr(conn, "working_secure_channel_mode", None)
+    candidates = _secure_mode_candidates(mode, cached_mode=cached_mode)
+    app = SecureApplet(conn)
+    failures = []
+
+    for index, candidate in enumerate(candidates):
+        sc = None
+        try:
+            if index > 0:
+                conn.disconnect()
+                conn.connect()
+            sc = app.open_secure_channel(mode=candidate)
+            if mode == AUTO_SECURE_CHANNEL_MODE:
+                data = app.secure_random(sc)
+                if len(data) != 32:
+                    raise RuntimeError(f"secure-random returned {len(data)} bytes instead of 32")
+            conn.working_secure_channel_mode = candidate
+            if mode == AUTO_SECURE_CHANNEL_MODE:
+                print(f"[info] using secure channel mode '{candidate}'.")
+            return sc
+        except Exception as e:
+            failures.append((candidate, e))
+            if sc is not None:
+                try:
+                    sc.close()
+                except Exception:
+                    pass
+
+    if mode != AUTO_SECURE_CHANNEL_MODE and failures:
+        raise failures[-1][1]
+
+    details = ", ".join(f"{candidate}: {error}" for candidate, error in failures)
+    raise RuntimeError(
+        "No working secure channel mode found "
+        f"(tried {', '.join(candidates)}). Details: {details}"
+    )
+
+
+def _open_sc_and_unlock(conn, pin_arg, mode=AUTO_SECURE_CHANNEL_MODE):
+    """Open a secure channel and optionally unlock with a PIN."""
+    sc = _open_sc(conn, mode=mode)
+    if pin_arg:
+        app = SecureApplet(conn)
+        status = app.pin_status(sc)
+        if status.get("status") == "disabled":
+            print("[info] PIN is disabled; ignoring provided --pin and continuing without unlock.")
+            return sc
+        if status.get("status") == "unlocked":
+            return sc
+        pin = pin_arg.encode() if isinstance(pin_arg, str) else pin_arg
+        try:
+            app.unlock(sc, pin)
+        except SecureError as e:
+            if e.code == "0505":
+                print(
+                    "[error] Failed to unlock: PIN is not set on this card. "
+                    "Use 'secure set-pin --pin <value>' to enable it.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"[error] Failed to unlock with provided PIN: "
+                    f"{_fmt_error(e.code, _SECURE_ERROR_DESCRIPTIONS)}",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# Teapot commands
+# ---------------------------------------------------------------------------
+
+def cmd_teapot_get(args, conn):
+    app = TeapotApplet(conn)
+    data = app.get()
+    try:
+        print(data.decode())
+    except UnicodeDecodeError:
+        _print_bytes(data, "data (hex)")
+
+
+def cmd_teapot_store(args, conn):
+    data = _bytes_arg(args.data, args.hex)
+    app = TeapotApplet(conn)
+    stored = app.store(data)
+    print("Stored successfully.")
+    try:
+        print(stored.decode())
+    except UnicodeDecodeError:
+        _print_bytes(stored, "stored (hex)")
+
+
+# ---------------------------------------------------------------------------
+# Secure commands
+# ---------------------------------------------------------------------------
+
+def cmd_secure_get_random(args, conn):
+    app = SecureApplet(conn)
+    _print_bytes(app.get_random(), "random")
+
+
+def cmd_secure_get_pubkey(args, conn):
+    app = SecureApplet(conn)
+    _print_bytes(app.get_pubkey(), "pubkey")
+
+
+def cmd_secure_pin_status(args, conn):
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, None, mode=args.secure_channel_mode)
+    status = app.pin_status(sc)
+    sc.close()
+    raw_status = status["status"]
+    if raw_status == "no_pin":
+        status_line = "no_pin  (PIN is disabled — no unlock required)"
+    elif raw_status == "unlocked":
+        status_line = "unlocked  (PIN is enabled and the card is currently unlocked for this session)"
+    elif raw_status == "locked":
+        status_line = "locked  (PIN is enabled; use --pin <value> or 'secure unlock' to unlock)"
+    else:
+        status_line = raw_status
+    print(f"Status:          {status_line}")
+    print(f"Attempts left:   {status['attempts_left']}")
+    print(f"Max attempts:    {status['max_attempts']}")
+
+
+def cmd_secure_set_pin(args, conn):
+    pin = args.pin.encode() if args.pin else None
+    if not pin:
+        print("[error] --pin is required for set-pin", file=sys.stderr)
+        sys.exit(1)
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, None, mode=args.secure_channel_mode)
+    app.set_pin(sc, pin)
+    sc.close()
+    print("PIN set successfully.")
+
+
+def cmd_secure_unset_pin(args, conn):
+    pin = args.pin.encode() if args.pin else None
+    if not pin:
+        print("[error] --pin is required for unset-pin", file=sys.stderr)
+        sys.exit(1)
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, pin, mode=args.secure_channel_mode)
+    app.unset_pin(sc, pin)
+    sc.close()
+    print("PIN unset successfully.")
+
+
+def cmd_secure_unlock(args, conn):
+    pin = args.pin.encode() if args.pin else None
+    if not pin:
+        print("[error] --pin is required for unlock", file=sys.stderr)
+        sys.exit(1)
+    app = SecureApplet(conn)
+    sc = _open_sc(conn, mode=args.secure_channel_mode)
+    app.unlock(sc, pin)
+    sc.close()
+    print("Card unlocked (this session only — unlock state is cleared when the applet is deselected).")
+
+
+def cmd_secure_lock(args, conn):
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    app.lock(sc)
+    sc.close()
+    print("Card locked.")
+
+
+def cmd_secure_change_pin(args, conn):
+    if not args.old_pin or not args.new_pin:
+        print("[error] --old-pin and --new-pin are required", file=sys.stderr)
+        sys.exit(1)
+    old = args.old_pin.encode()
+    new = args.new_pin.encode()
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, old, mode=args.secure_channel_mode)
+    app.change_pin(sc, old, new)
+    sc.close()
+    print("PIN changed successfully.")
+
+
+def cmd_secure_echo(args, conn):
+    data = _bytes_arg(args.data, args.hex)
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    result = app.echo(sc, data)
+    sc.close()
+    try:
+        print(result.decode())
+    except UnicodeDecodeError:
+        _print_bytes(result, "echo (hex)")
+
+
+def cmd_secure_secure_random(args, conn):
+    app = SecureApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    _print_bytes(app.secure_random(sc), "random")
+    sc.close()
+
+
+def cmd_secure_probe_modes(args, conn):
+    app = SecureApplet(conn)
+    failures = []
+
+    for index, mode in enumerate(SUPPORTED_SECURE_CHANNEL_MODES):
+        sc = None
+        try:
+            if index > 0:
+                # Start each mode probe from a fresh transport/app selection so
+                # one failed or stale secure-channel session does not taint the next.
+                conn.disconnect()
+                conn.connect()
+            sc = app.open_secure_channel(mode=mode)
+            data = app.secure_random(sc)
+            if len(data) != 32:
+                raise RuntimeError(f"secure-random returned {len(data)} bytes instead of 32")
+            print(f"[ok] {mode}: opened secure channel and fetched 32 secure random bytes")
+        except Exception as e:
+            failures.append(mode)
+            print(f"[fail] {mode}: {e}")
+        finally:
+            if sc is not None:
+                try:
+                    sc.close()
+                except Exception:
+                    pass
+
+    succeeded = len(SUPPORTED_SECURE_CHANNEL_MODES) - len(failures)
+    total = len(SUPPORTED_SECURE_CHANNEL_MODES)
+    print(f"Summary: {succeeded}/{total} modes succeeded.")
+    if failures:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# MemoryCard commands
+# ---------------------------------------------------------------------------
+
+def cmd_memorycard_get(args, conn):
+    app = MemoryCardApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    data = app.get_data(sc)
+    sc.close()
+    if not data:
+        print("[info] No data stored on card.")
+        return
+    _print_bytes(data, "data (hex)")
+
+    device_secret = _parse_device_secret_hex(args.device_secret)
+    try:
+        result = parse_sdiy_blob(data, device_secret=device_secret)
+    except DecryptionError:
+        return
+
+    print("specter-diy decode:")
+    print(f"  encrypted: {result['encrypted']}")
+    print(f"  entropy:   {result['entropy'].hex()}")
+    if result["mnemonic"] is not None:
+        print(f"  mnemonic:  {result['mnemonic']}")
+    else:
+        print("  mnemonic:  (install 'embit' to decode entropy to BIP-39 words)")
+
+
+def cmd_memorycard_store(args, conn):
+    data = _bytes_arg(args.data, args.hex)
+    app = MemoryCardApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    stored = app.store_data(sc, data)
+    sc.close()
+    print("Stored successfully.")
+    try:
+        print(stored.decode())
+    except UnicodeDecodeError:
+        _print_bytes(stored, "stored (hex)")
+
+
+def cmd_memorycard_decode_diy(args, conn):
+    device_secret = _parse_device_secret_hex(args.device_secret)
+    app = MemoryCardApplet(conn)
+    sc  = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    try:
+        result = app.decode_diy_data(sc, device_secret=device_secret)
+    except DecryptionError as e:
+        print(f"[error] {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        sc.close()
+    print(f"encrypted: {result['encrypted']}")
+    print(f"entropy:   {result['entropy'].hex()}")
+    if result["mnemonic"] is not None:
+        print(f"mnemonic:  {result['mnemonic']}")
+    else:
+        print("mnemonic:  (install 'embit' to decode entropy to BIP-39 words)")
+
+
+# ---------------------------------------------------------------------------
+# BlindOracle commands
+# ---------------------------------------------------------------------------
+
+def cmd_blindoracle_set_seed(args, conn):
+    seed = _bytes_arg(args.seed, args.hex)
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    xpub = app.set_seed(sc, seed)
+    sc.close()
+    _print_bytes(xpub, "root xpub")
+
+
+def cmd_blindoracle_set_xprv(args, conn):
+    xprv = _bytes_arg(args.xprv, args.hex)
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    xpub = app.set_root_key(sc, xprv)
+    sc.close()
+    _print_bytes(xpub, "root xpub")
+
+
+def cmd_blindoracle_gen_key(args, conn):
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    xpub = app.generate_random_key(sc)
+    sc.close()
+    _print_bytes(xpub, "root xpub")
+
+
+def cmd_blindoracle_get_root_xpub(args, conn):
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    xpub = app.get_root_xpub(sc)
+    sc.close()
+    _print_bytes(xpub, "root xpub")
+
+
+def cmd_blindoracle_derive(args, conn):
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    from_root = args.from_key != "child"
+    xpub = app.derive_child(sc, args.path, from_root=from_root)
+    sc.close()
+    _print_bytes(xpub, "child xpub")
+
+
+def cmd_blindoracle_get_child(args, conn):
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    xpub = app.get_current_child(sc)
+    sc.close()
+    _print_bytes(xpub, "child xpub")
+
+
+def cmd_blindoracle_sign(args, conn):
+    msg_hash = bytes.fromhex(args.hash)
+    if len(msg_hash) != 32:
+        print("[error] --hash must be exactly 32 bytes (64 hex chars)", file=sys.stderr)
+        sys.exit(1)
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    use_root = args.key != "child"
+    sig = app.sign(sc, msg_hash, use_root=use_root)
+    sc.close()
+    _print_bytes(sig, "signature (DER)")
+
+
+def cmd_blindoracle_derive_sign(args, conn):
+    msg_hash = bytes.fromhex(args.hash)
+    if len(msg_hash) != 32:
+        print("[error] --hash must be exactly 32 bytes (64 hex chars)", file=sys.stderr)
+        sys.exit(1)
+    app = BlindOracleApplet(conn)
+    sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+    from_root = args.from_key != "child"
+    sig = app.derive_and_sign(sc, msg_hash, args.path, from_root=from_root)
+    sc.close()
+    _print_bytes(sig, "signature (DER)")
+
+
+# ---------------------------------------------------------------------------
+# SingleUseKey commands
+# ---------------------------------------------------------------------------
+
+def cmd_singleusekey_generate(args, conn):
+    app = SingleUseKeyApplet(conn)
+    if args.secure:
+        sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+        pub = app.sc_generate(sc)
+        sc.close()
+    else:
+        pub = app.generate()
+    _print_bytes(pub, "pubkey")
+
+
+def cmd_singleusekey_get_pubkey(args, conn):
+    app = SingleUseKeyApplet(conn)
+    if args.secure:
+        sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+        pub = app.sc_get_pubkey(sc)
+        sc.close()
+    else:
+        pub = app.get_pubkey()
+    _print_bytes(pub, "pubkey")
+
+
+def cmd_singleusekey_sign(args, conn):
+    msg_hash = bytes.fromhex(args.hash)
+    if len(msg_hash) != 32:
+        print("[error] --hash must be exactly 32 bytes (64 hex chars)", file=sys.stderr)
+        sys.exit(1)
+    app = SingleUseKeyApplet(conn)
+    if args.secure:
+        sc = _open_sc_and_unlock(conn, args.pin.encode() if args.pin else None, mode=args.secure_channel_mode)
+        sig = app.sc_sign(sc, msg_hash)
+        sc.close()
+    else:
+        sig = app.sign(msg_hash)
+    _print_bytes(sig, "signature (DER)")
+
+
+def cmd_discover(args):
+    if args.mode == "simulator":
+        print("[error] discover is only supported with --mode card", file=sys.stderr)
+        sys.exit(1)
+
+    found = []
+    for name, (aid, _, _) in APPLET_META.items():
+        conn = Card(aid)
+        try:
+            conn.connect()
+            found.append((name, aid))
+        except ISOException as e:
+            if e.code != "6a82":
+                print(f"{name:12} AID {aid} -> error {e.code}")
+        except Exception as e:
+            print(f"{name:12} AID {aid} -> error {e}")
+        finally:
+            try:
+                conn.disconnect()
+            except Exception:
+                pass
+
+    if not found:
+        print("No known Specter applets found on card.")
+        return
+
+    print("Detected applets:")
+    for name, aid in found:
+        print(f"- {name:12} {aid}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parser construction
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="specter-card",
+        description="CLI for Specter JavaCard applets",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Global options
+    parser.add_argument(
+        "--mode", choices=["card", "simulator"], default="card",
+        help="Connection mode: 'card' (real smartcard, default) or 'simulator' (local Java simulator).",
+    )
+    parser.add_argument(
+        "--aid", default=None,
+        help="Override the applet AID (hex string). Uses applet default if not provided.",
+    )
+    parser.add_argument(
+        "--pin", default=None,
+        help="PIN code to unlock the card before executing a command (string).",
+    )
+    parser.add_argument(
+        "--port", type=int, default=6666,
+        help="Simulator TCP port (default: 6666, only used with --mode simulator).",
+    )
+    parser.add_argument(
+        "--secure-channel-mode",
+        dest="secure_channel_mode",
+        choices=(AUTO_SECURE_CHANNEL_MODE,) + AUTO_SECURE_CHANNEL_MODE_PRIORITY,
+        default=AUTO_SECURE_CHANNEL_MODE,
+        help=(
+            "Secure-channel mode to use for encrypted commands. "
+            "Default: auto (probe a working mode, preferring ee)."
+        ),
+    )
+
+    subparsers = parser.add_subparsers(dest="applet", metavar="<applet>")
+    subparsers.required = True
+
+    subparsers.add_parser(
+        "discover",
+        help="Probe the card for known Specter applet AIDs.",
+    )
+
+    # ------------------------------------------------------------------ teapot
+    tp = subparsers.add_parser("teapot", help="Simple plaintext data store (no PIN).")
+    tp_sub = tp.add_subparsers(dest="command", metavar="<command>")
+    tp_sub.required = True
+
+    tp_sub.add_parser("get", help="Print the data currently stored on the card.")
+
+    tp_store = tp_sub.add_parser("store", help="Write data to the card.")
+    tp_store.add_argument("data", help="Data to store (string or hex).")
+    tp_store.add_argument(
+        "--hex", action="store_true", help="Interpret DATA as a hex string."
+    )
+
+    # ------------------------------------------------------------------ secure
+    sec = subparsers.add_parser("secure", help="SecureApplet – random, pubkey, PIN.")
+    sec_sub = sec.add_subparsers(dest="command", metavar="<command>")
+    sec_sub.required = True
+
+    sec_sub.add_parser("get-random", help="Return 32 random bytes (plaintext APDU).")
+    sec_sub.add_parser("get-pubkey", help="Return the card static public key (65 bytes).")
+    sec_sub.add_parser("pin-status", help="Show PIN status (attempts left, locked/unlocked).")
+
+    sp = sec_sub.add_parser("set-pin", help="Enable and set the PIN code.")
+    sp.add_argument("--pin", required=True, help="New PIN value (string).")
+
+    up = sec_sub.add_parser("unset-pin", help="Disable PIN. Card must be unlocked first.")
+    up.add_argument("--pin", required=True, help="Current PIN to confirm.")
+
+    sec_sub.add_parser(
+        "unlock",
+        help=(
+            "Unlock the card for the current session using the global --pin option. "
+            "This does NOT remove the PIN; the card will return to a locked state after "
+            "the next power-cycle or explicit 'lock'. "
+            "To permanently disable the PIN, use 'unset-pin'."
+        ),
+    )
+    sec_sub.add_parser("lock",   help="Lock the card.")
+
+    cp = sec_sub.add_parser("change-pin", help="Change the PIN code.")
+    cp.add_argument("--old-pin", required=True, help="Current PIN.")
+    cp.add_argument("--new-pin", required=True, help="New PIN.")
+
+    echo_p = sec_sub.add_parser("echo", help="Send data through the secure channel and receive it back.")
+    echo_p.add_argument("data", help="Data to echo (string or hex).")
+    echo_p.add_argument("--hex", action="store_true", help="Interpret DATA as hex.")
+
+    sec_sub.add_parser("secure-random", help="Return 32 random bytes over the secure channel.")
+    sec_sub.add_parser(
+        "probe-modes",
+        help="Try ss/es/ee secure-channel modes and run secure-random in each.",
+    )
+
+    # ------------------------------------------------------------------ memorycard
+    mc = subparsers.add_parser("memorycard", help="Secure byte-string storage (PIN-protected).")
+    mc_sub = mc.add_subparsers(dest="command", metavar="<command>")
+    mc_sub.required = True
+
+    mc_get = mc_sub.add_parser(
+        "get",
+        help="Retrieve raw card bytes (hex) and attempt Specter-DIY decode.",
+    )
+    mc_get.add_argument(
+        "--device-secret", default=None, metavar="HEX",
+        help=(
+            "Optional 32-byte internal secret from the Specter-DIY device's MCU flash "
+            "(hex string). Used when decoding encrypted Specter-DIY blobs."
+        ),
+    )
+
+    mc_store = mc_sub.add_parser("store", aliases=["set"], help="Write a secret to the card (up to 220 bytes).")
+    mc_store.add_argument("data", help="Data to store (string or hex).")
+    mc_store.add_argument("--hex", action="store_true", help="Interpret DATA as hex.")
+
+    mc_diy = mc_sub.add_parser(
+        "decode-diy",
+        help=(
+            "Decrypt and decode a Specter-DIY blob stored on the card. "
+            "For encrypted blobs, supply the 32-byte device secret via "
+            "--device-secret (hex). Unencrypted blobs need no secret."
+        ),
+    )
+    mc_diy.add_argument(
+        "--device-secret", default=None, metavar="HEX",
+        help=(
+            "32-byte internal secret from the Specter-DIY device's MCU flash "
+            "(hex string). Required for encrypted blobs."
+        ),
+    )
+
+    # ------------------------------------------------------------------ blindoracle
+    bo = subparsers.add_parser(
+        "blindoracle",
+        help="BIP-32 HD key storage, derivation, and signing."
+    )
+    bo_sub = bo.add_subparsers(dest="command", metavar="<command>")
+    bo_sub.required = True
+
+    ss = bo_sub.add_parser("set-seed", help="Import a BIP-32 seed (16-64 bytes) as the root key.")
+    ss.add_argument("seed", help="Seed bytes (string or hex).")
+    ss.add_argument("--hex", action="store_true", help="Interpret SEED as hex.")
+
+    sx = bo_sub.add_parser("set-xprv", help="Import an existing xprv (chain_code + 0x00 + privkey, 65 bytes).")
+    sx.add_argument("xprv", help="xprv bytes (hex).")
+    sx.add_argument("--hex", action="store_true", default=True, help="Interpret XPRV as hex (default).")
+
+    bo_sub.add_parser("gen-key",      help="Generate a random root key on the card (no backup possible!).")
+    bo_sub.add_parser("get-root-xpub", help="Return the root xpub (chain_code + pubkey, 65 bytes).")
+    bo_sub.add_parser("get-child",    help="Return the currently cached child xpub.")
+
+    dv = bo_sub.add_parser("derive", help="Derive a child key and cache it on the card.")
+    dv.add_argument("path", help="BIP-32 derivation path, e.g. \"m/44'/0'/0'\".")
+    dv.add_argument(
+        "--from", dest="from_key", choices=["root", "child"], default="root",
+        help="Derive from 'root' (default) or the previously cached 'child'.",
+    )
+
+    sg = bo_sub.add_parser("sign", help="Sign a 32-byte hash with the root or cached child key.")
+    sg.add_argument("--hash", required=True, help="32-byte message hash (64 hex chars).")
+    sg.add_argument(
+        "--key", choices=["root", "child"], default="root",
+        help="Key to sign with: 'root' (default) or 'child'.",
+    )
+
+    ds = bo_sub.add_parser(
+        "derive-sign",
+        help="Derive a key, sign a hash, and discard the temporary key (card state unchanged).",
+    )
+    ds.add_argument("--hash", required=True, help="32-byte message hash (64 hex chars).")
+    ds.add_argument("path", help="BIP-32 derivation path.")
+    ds.add_argument(
+        "--from", dest="from_key", choices=["root", "child"], default="root",
+        help="Derive from 'root' (default) or currently cached 'child'.",
+    )
+
+    # ------------------------------------------------------------------ singleusekey
+    suk = subparsers.add_parser(
+        "singleusekey",
+        help="Single-use key: generate, get pubkey, sign once."
+    )
+    suk_sub = suk.add_subparsers(dest="command", metavar="<command>")
+    suk_sub.required = True
+
+    for cmd_name, help_text in [
+        ("generate",   "Generate a new single-use key and return its public key."),
+        ("get-pubkey", "Return the current single-use public key."),
+    ]:
+        p = suk_sub.add_parser(cmd_name, help=help_text)
+        p.add_argument(
+            "--secure", action="store_true",
+            help="Use the secure channel (PIN-protected).",
+        )
+
+    sign_p = suk_sub.add_parser(
+        "sign",
+        help="Sign a 32-byte hash. The key is replaced after signing.",
+    )
+    sign_p.add_argument("--hash", required=True, help="32-byte message hash (64 hex chars).")
+    sign_p.add_argument(
+        "--secure", action="store_true",
+        help="Use the secure channel (PIN-protected).",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+COMMANDS = {
+    ("teapot",       "get"):            cmd_teapot_get,
+    ("teapot",       "store"):          cmd_teapot_store,
+    ("secure",       "get-random"):     cmd_secure_get_random,
+    ("secure",       "get-pubkey"):     cmd_secure_get_pubkey,
+    ("secure",       "pin-status"):     cmd_secure_pin_status,
+    ("secure",       "set-pin"):        cmd_secure_set_pin,
+    ("secure",       "unset-pin"):      cmd_secure_unset_pin,
+    ("secure",       "unlock"):         cmd_secure_unlock,
+    ("secure",       "lock"):           cmd_secure_lock,
+    ("secure",       "change-pin"):     cmd_secure_change_pin,
+    ("secure",       "echo"):           cmd_secure_echo,
+    ("secure",       "secure-random"):  cmd_secure_secure_random,
+    ("secure",       "probe-modes"):    cmd_secure_probe_modes,
+    ("memorycard",   "get"):            cmd_memorycard_get,
+    ("memorycard",   "store"):          cmd_memorycard_store,
+    ("memorycard",   "set"):            cmd_memorycard_store,
+    ("memorycard",   "decode-diy"):     cmd_memorycard_decode_diy,
+    ("blindoracle",  "set-seed"):       cmd_blindoracle_set_seed,
+    ("blindoracle",  "set-xprv"):       cmd_blindoracle_set_xprv,
+    ("blindoracle",  "gen-key"):        cmd_blindoracle_gen_key,
+    ("blindoracle",  "get-root-xpub"): cmd_blindoracle_get_root_xpub,
+    ("blindoracle",  "derive"):         cmd_blindoracle_derive,
+    ("blindoracle",  "get-child"):      cmd_blindoracle_get_child,
+    ("blindoracle",  "sign"):           cmd_blindoracle_sign,
+    ("blindoracle",  "derive-sign"):    cmd_blindoracle_derive_sign,
+    ("singleusekey", "generate"):       cmd_singleusekey_generate,
+    ("singleusekey", "get-pubkey"):     cmd_singleusekey_get_pubkey,
+    ("singleusekey", "sign"):           cmd_singleusekey_sign,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.applet == "discover":
+        cmd_discover(args)
+        return
+
+    # Build connection
+    try:
+        conn, _ = _make_connection(args, args.applet)
+    except Exception as e:
+        print(f"[error] Could not connect: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Dispatch
+    key = (args.applet, args.command)
+    handler = COMMANDS.get(key)
+    if handler is None:
+        print(f"[error] Unknown command: {args.applet} {args.command}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        handler(args, conn)
+    except ISOException as e:
+        print(f"[error] ISO error: {_fmt_error(e.code, _ISO_ERROR_DESCRIPTIONS)}", file=sys.stderr)
+        sys.exit(1)
+    except SecureError as e:
+        if e.code == "0501" and not getattr(args, "pin", None):
+            print(
+                "[error] Card is locked. Provide a PIN with --pin to unlock it.",
+                file=sys.stderr,
+            )
+        elif e.code == "0502":
+            print(
+                "[error] Wrong PIN. Check your PIN value and run 'secure pin-status' to see attempts remaining.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"[error] Secure channel error: {_fmt_error(e.code, _SECURE_ERROR_DESCRIPTIONS)}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"[error] {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        try:
+            conn.disconnect()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/py/specter_card/connection.py
+++ b/py/specter_card/connection.py
@@ -1,0 +1,170 @@
+"""
+Connection helpers: Card (real smartcard via pyscard) and Simulator (local Java simulator).
+"""
+import socket
+import subprocess
+import time
+import os
+
+
+def _is_card_reset_error(exc):
+    """Return True if *exc* is a recoverable card-reset error.
+
+    On Windows the WinSCard service resets the card when a T=1 transaction
+    takes too long (e.g. during the ECDH+sign step of opening a secure
+    channel).  The error is ``SCARD_W_RESET_CARD`` (0x80100068).  Other
+    PC/SC implementations report similar "card reset" messages.
+    """
+    msg = str(exc)
+    return "0x80100068" in msg or (
+        "reset" in msg.lower() and ("card" in msg.lower() or "scard" in msg.lower())
+    )
+
+SIMULATOR_JAR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../simulator.jar")
+)
+CLASSES_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../build/classes")
+)
+SIMULATOR_HOST = "127.0.0.1"
+SIMULATOR_PORT = 6666
+MAX_RESPONSE_LEN = 256
+
+
+class ISOException(Exception):
+    """Raised when the card returns a non-9000 status word."""
+    def __init__(self, code):
+        self.code = code
+        super().__init__(f"ISO error: {code}")
+
+
+class Card:
+    """
+    Communicates with a real smartcard via pyscard.
+
+    Parameters
+    ----------
+    aid : str
+        Hex-encoded application identifier, e.g. ``"B00B5111CA01"``.
+    """
+
+    def __init__(self, aid: str):
+        self.aid = aid
+        self._conn = None
+
+    # ------------------------------------------------------------------
+    def connect(self):
+        from smartcard.System import readers
+        from smartcard.CardConnection import CardConnection
+        rarr = readers()
+        if not rarr:
+            raise RuntimeError("No smartcard reader found")
+        reader = rarr[0]
+        self._conn = reader.createConnection()
+        self._conn.connect(CardConnection.T1_protocol)
+        # Select the applet
+        aid_bytes = list(bytes.fromhex(self.aid))
+        apdu = [0x00, 0xA4, 0x04, 0x00, len(aid_bytes)] + aid_bytes + [0x00]
+        data, sw1, sw2 = self._conn.transmit(apdu)
+        sw = bytes([sw1, sw2])
+        if sw != b"\x90\x00":
+            raise ISOException(sw.hex())
+
+    def disconnect(self):
+        if self._conn is not None:
+            self._conn.disconnect()
+            self._conn = None
+
+    def _reconnect_and_reselect(self):
+        """Re-establish the connection after a card reset.
+
+        Calls :meth:`disconnect` then :meth:`connect` so that the full
+        sequence (reader discovery → T1 connect → applet SELECT) is
+        repeated with the same logic used on initial connection.
+        """
+        self.disconnect()
+        self.connect()
+
+    def transmit(self, apdu):
+        try:
+            data, sw1, sw2 = self._conn.transmit(list(apdu))
+            return list(data), sw1, sw2
+        except Exception as e:
+            if not _is_card_reset_error(e):
+                raise
+            # The card was reset mid-transaction (e.g. Windows
+            # SCARD_W_RESET_CARD 0x80100068 during long card-side crypto).
+            # Re-establish the full session and retry the APDU once.
+            self._reconnect_and_reselect()
+            data, sw1, sw2 = self._conn.transmit(list(apdu))
+            return list(data), sw1, sw2
+
+    def request(self, apdu: bytes) -> bytes:
+        """Send *apdu* and return response data, raising :exc:`ISOException` on error."""
+        data, sw1, sw2 = self.transmit(list(apdu))
+        sw = bytes([sw1, sw2])
+        if sw != b"\x90\x00":
+            raise ISOException(sw.hex())
+        return bytes(data)
+
+
+class Simulator:
+    """
+    Spawns the javacard simulator JAR and communicates over a local TCP socket.
+
+    Parameters
+    ----------
+    aid : str
+        Hex-encoded AID.
+    applet : str
+        Fully-qualified Java class name, e.g. ``"toys.TeapotApplet"``.
+    classdir : str
+        Sub-directory inside ``build/classes/`` where the compiled class lives.
+    port : int
+        TCP port the simulator will listen on (default: 6666).
+    """
+
+    def __init__(self, aid: str, applet: str, classdir: str, port: int = SIMULATOR_PORT):
+        self.aid = aid
+        self.applet = applet
+        self.url = f"file://{CLASSES_PATH}/{classdir}/"
+        self.port = port
+        self._proc = None
+        self._sock = None
+
+    def connect(self):
+        args = [
+            "java", "-jar", SIMULATOR_JAR,
+            "-p", str(self.port),
+            "-a", self.aid,
+            "-c", self.applet,
+            "-u", self.url,
+        ]
+        self._proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(1)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.connect((SIMULATOR_HOST, self.port))
+
+    def disconnect(self):
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
+        if self._proc is not None:
+            self._proc.kill()
+            self._proc = None
+            time.sleep(0.5)
+
+    def transmit(self, apdu):
+        self._sock.sendall(bytes(apdu))
+        data = self._sock.recv(MAX_RESPONSE_LEN)
+        sw = list(data[-2:])
+        response = list(data[:-2])
+        return response, sw[0], sw[1]
+
+    def request(self, apdu: bytes) -> bytes:
+        """Send *apdu* and return response data, raising :exc:`ISOException` on error."""
+        data, sw1, sw2 = self.transmit(list(apdu))
+        sw = bytes([sw1, sw2])
+        if sw != b"\x90\x00":
+            raise ISOException(sw.hex())
+        return bytes(data)

--- a/py/specter_card/diy_crypt.py
+++ b/py/specter_card/diy_crypt.py
@@ -1,0 +1,304 @@
+"""Specter-DIY storage format decoder.
+
+Implements the same crypto primitives used by the Specter-DIY firmware's
+MemoryCard keystore (``src/keystore/memorycard.py`` in specter-diy) so that
+blobs stored on a MemoryCard applet can be decrypted and parsed offline.
+
+Two storage modes exist:
+
+* **Encrypted** – key derived from the Specter-DIY device's internal secret:
+
+  .. code-block:: python
+
+      key        = tagged_hash("scenc", device_secret)
+      fingerprint = tagged_hash("scid",  device_secret)[:4]
+
+* **Unencrypted** – fixed public key (user opted to store in plain text):
+
+  .. code-block:: python
+
+      key        = b"\\xcc" * 32
+      fingerprint = b"\\x00" * 4
+
+Blob wire format (output of specter-diy's ``aead_encrypt``):
+
+.. code-block:: text
+
+    compact_varint(len(adata)) | adata | IV(16) | AES-CBC(padded_plaintext) | HMAC-SHA256(32)
+
+TLV plaintext (single-byte key, single-byte length):
+
+.. code-block:: text
+
+    \\x01 <len> <enc_key>   – optional encryption-key field
+    \\x02 <len> <entropy>   – BIP-39 entropy bytes (16–32 bytes)
+"""
+import hashlib
+import hmac as _hmac
+import struct
+from io import BytesIO
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+__all__ = [
+    "tagged_hash",
+    "aead_decrypt",
+    "parse_sdiy_blob",
+    "DecryptionError",
+]
+
+# ── constants ────────────────────────────────────────────────────────────────
+
+_SDIY_MAGIC = b"sdiy\x00"
+_FIXED_KEY  = b"\xcc" * 32   # key used for unencrypted storage
+_FIXED_FP   = b"\x00" * 4    # fingerprint used for unencrypted storage
+_IV_SIZE    = 16
+_MAC_SIZE   = 32
+_BLOCK      = 16
+
+
+# ── exceptions ───────────────────────────────────────────────────────────────
+
+class DecryptionError(Exception):
+    """Raised when decryption or format validation fails."""
+
+
+# ── low-level primitives ─────────────────────────────────────────────────────
+
+def tagged_hash(tag: str, data: bytes) -> bytes:
+    """BIP-Schnorr style tagged hash: ``SHA256(SHA256(tag) || SHA256(tag) || data)``."""
+    hashtag = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(hashtag + hashtag + data).digest()
+
+
+def _compact_read(stream) -> int:
+    """Read a Bitcoin CompactSize (varint) integer from *stream*."""
+    first = stream.read(1)
+    if not first:
+        raise DecryptionError("Truncated compact varint")
+    v = first[0]
+    if v < 0xFD:
+        return v
+    if v == 0xFD:
+        raw = stream.read(2)
+        if len(raw) < 2:
+            raise DecryptionError("Truncated compact varint (0xFD)")
+        return struct.unpack_from("<H", raw)[0]
+    if v == 0xFE:
+        raw = stream.read(4)
+        if len(raw) < 4:
+            raise DecryptionError("Truncated compact varint (0xFE)")
+        return struct.unpack_from("<I", raw)[0]
+    raw = stream.read(8)
+    if len(raw) < 8:
+        raise DecryptionError("Truncated compact varint (0xFF)")
+    return struct.unpack_from("<Q", raw)[0]
+
+
+def _aes_cbc_decrypt(data: bytes, key: bytes) -> bytes:
+    """AES-CBC decrypt; the first 16 bytes of *data* are the IV."""
+    if len(data) < _IV_SIZE:
+        raise DecryptionError("Ciphertext too short for IV")
+    iv, ct = data[:_IV_SIZE], data[_IV_SIZE:]
+    if len(ct) % _BLOCK != 0:
+        raise DecryptionError("Ciphertext length is not a multiple of the AES block size")
+    dec = Cipher(algorithms.AES(key), modes.CBC(iv)).decryptor()
+    return dec.update(ct) + dec.finalize()
+
+
+def _remove_sdiy_padding(data: bytes) -> bytes:
+    """Remove the ``0x80 + zero*`` padding added by specter-diy's ``encrypt()``."""
+    idx = data.rfind(b"\x80")
+    if idx < 0:
+        raise DecryptionError("Padding byte 0x80 not found in decrypted data")
+    tail = data[idx + 1:]
+    if tail != b"\x00" * len(tail):
+        raise DecryptionError("Invalid padding: non-zero bytes after 0x80")
+    return data[:idx]
+
+
+# ── public API ───────────────────────────────────────────────────────────────
+
+def aead_decrypt(ciphertext: bytes, key: bytes):
+    """Verify HMAC and decrypt a specter-diy AEAD blob.
+
+    Parameters
+    ----------
+    ciphertext : bytes
+        Raw blob as returned by ``MemoryCardApplet.get_data()``.
+    key : bytes
+        32-byte decryption key.
+
+    Returns
+    -------
+    adata : bytes
+        Associated data (unencrypted prefix – includes MAGIC + fingerprint).
+    plaintext : bytes
+        Decrypted TLV payload.
+
+    Raises
+    ------
+    DecryptionError
+        On HMAC mismatch or any format error.
+    """
+    if len(ciphertext) < _MAC_SIZE:
+        raise DecryptionError("Ciphertext too short")
+
+    mac_expected = ciphertext[-_MAC_SIZE:]
+    body         = ciphertext[:-_MAC_SIZE]
+
+    aes_key  = tagged_hash("aes",  key)
+    hmac_key = tagged_hash("hmac", key)
+
+    mac_actual = _hmac.new(hmac_key, body, digestmod="sha256").digest()
+    if mac_actual != mac_expected:
+        raise DecryptionError("HMAC verification failed – wrong key or corrupted data")
+
+    stream    = BytesIO(body)
+    adata_len = _compact_read(stream)
+    adata     = stream.read(adata_len)
+    if len(adata) != adata_len:
+        raise DecryptionError("Truncated associated data")
+
+    encrypted_payload = stream.read()
+    if not encrypted_payload:
+        return adata, b""
+
+    raw       = _aes_cbc_decrypt(encrypted_payload, aes_key)
+    plaintext = _remove_sdiy_padding(raw)
+    return adata, plaintext
+
+
+def _decode_tlv(data: bytes) -> dict:
+    """Parse the specter-diy TLV plaintext into a dict with string keys.
+
+    Known fields:
+
+    * ``"enc"``     – optional encryption-key field (tag ``0x01``)
+    * ``"entropy"`` – BIP-39 entropy bytes (tag ``0x02``)
+    """
+    KEY_MAP = {0x01: "enc", 0x02: "entropy"}
+    result  = {}
+    stream  = BytesIO(data)
+    while True:
+        k = stream.read(1)
+        if not k:
+            break
+        l_byte = stream.read(1)
+        if not l_byte:
+            raise DecryptionError("Truncated TLV: missing length byte")
+        length = l_byte[0]
+        value  = stream.read(length)
+        if len(value) != length:
+            raise DecryptionError("Truncated TLV: value shorter than declared length")
+        name = KEY_MAP.get(k[0])
+        if name:
+            result[name] = value
+    return result
+
+
+def parse_sdiy_blob(raw: bytes, device_secret: bytes = None) -> dict:
+    """Decrypt and parse a Specter-DIY MemoryCard blob.
+
+    Specter-DIY stores BIP-39 entropy on the card wrapped in an AEAD envelope.
+    Two modes exist:
+
+    * **Unencrypted** – ``device_secret`` is not needed; the fixed key
+      ``b"\\xcc"*32`` is used.
+    * **Encrypted** – the key is ``tagged_hash("scenc", device_secret)``.
+      *device_secret* is the 32-byte internal secret stored in the
+      Specter-DIY device's MCU flash (found at ``<storage_path>/secret``).
+
+    Parameters
+    ----------
+    raw : bytes
+        Raw bytes returned by ``MemoryCardApplet.get_data()``.
+    device_secret : bytes, optional
+        32-byte device secret.  Required for encrypted blobs; ignored for
+        unencrypted blobs.
+
+    Returns
+    -------
+    dict
+        Keys:
+
+        * ``"entropy"``   – :class:`bytes`: raw BIP-39 entropy (16–32 bytes)
+        * ``"encrypted"`` – :class:`bool`: whether the blob was encrypted
+        * ``"mnemonic"``  – :class:`str` or ``None``: BIP-39 mnemonic phrase
+          (populated only when the ``embit`` package is available)
+
+    Raises
+    ------
+    DecryptionError
+        If decryption fails or the blob is not a valid Specter-DIY storage blob.
+    """
+    if len(raw) == 0:
+        raise DecryptionError("Card returned empty data – no secret is stored")
+
+    # Minimum blob: 0x09 (varint) + 9-byte adata + 32-byte HMAC = 42 bytes.
+    # adata = MAGIC(5) + fingerprint(4)
+    _MIN_LEN = 1 + len(_SDIY_MAGIC) + 4 + _MAC_SIZE
+    if len(raw) < _MIN_LEN:
+        raise DecryptionError("Blob too short to be a valid Specter-DIY storage blob")
+
+    # Peek at the adata (without consuming the blob) to detect storage mode.
+    peek = BytesIO(raw[:-_MAC_SIZE])
+    adata_len  = _compact_read(peek)
+    if adata_len < len(_SDIY_MAGIC) + 4:
+        raise DecryptionError("Associated data is too short")
+    adata_peek = peek.read(adata_len)
+    if len(adata_peek) != adata_len:
+        raise DecryptionError("Truncated associated data")
+
+    if not adata_peek.startswith(_SDIY_MAGIC):
+        raise DecryptionError(
+            "Magic bytes not found – this does not appear to be a Specter-DIY blob"
+        )
+
+    fingerprint = adata_peek[len(_SDIY_MAGIC): len(_SDIY_MAGIC) + 4]
+
+    if fingerprint == _FIXED_FP:
+        # Unencrypted blob: fixed public key
+        key       = _FIXED_KEY
+        encrypted = False
+    else:
+        # Encrypted blob
+        if device_secret is None:
+            raise DecryptionError(
+                "Blob is encrypted. Provide the 32-byte internal secret from the "
+                "Specter-DIY device's MCU flash storage via --device-secret."
+            )
+        if len(device_secret) != 32:
+            raise DecryptionError(
+                f"device_secret must be exactly 32 bytes, got {len(device_secret)}"
+            )
+        expected_fp = tagged_hash("scid", device_secret)[:4]
+        if fingerprint != expected_fp:
+            raise DecryptionError(
+                "Fingerprint mismatch – device_secret does not belong to the device "
+                "that encrypted this blob."
+            )
+        key       = tagged_hash("scenc", device_secret)
+        encrypted = True
+
+    _, plaintext = aead_decrypt(raw, key)
+    fields       = _decode_tlv(plaintext)
+
+    if "entropy" not in fields:
+        raise DecryptionError("No entropy field found in decrypted payload")
+
+    entropy = fields["entropy"]
+
+    # Convert entropy to a BIP-39 mnemonic when embit is available.
+    mnemonic = None
+    try:
+        from embit import bip39 as _bip39  # optional dependency
+        mnemonic = _bip39.mnemonic_from_bytes(entropy)
+    except ImportError:
+        pass
+
+    return {
+        "entropy":   entropy,
+        "encrypted": encrypted,
+        "mnemonic":  mnemonic,
+    }

--- a/py/specter_card/securechannel.py
+++ b/py/specter_card/securechannel.py
@@ -1,0 +1,245 @@
+"""
+Secure channel implementation compatible with the JavaCard SecureApplet.
+
+Supports ``ss`` (both host and card use static keys with nonces),
+``es`` (host-ephemeral / card-static), and ``ee`` (both ephemeral) modes.
+"""
+import hashlib, hmac, os
+from io import BytesIO
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    derive_private_key, EllipticCurvePublicKey, SECP256K1, ECDH, ECDSA,
+)
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.exceptions import InvalidSignature
+
+_encode = lambda data: bytes([len(data)]) + data
+
+HMAC_LEN = 14
+MAX_IV = 2 ** 16
+
+# APDU bytes
+_CLA = 0xB0
+_INS_GET_PUBKEY      = 0xB2
+_INS_OPEN_SS         = 0xB3  # ss mode
+_INS_OPEN_SE         = 0xB4  # es mode
+_INS_OPEN_EE         = 0xB5  # ee mode
+_INS_SECURE_MESSAGE  = 0xB6
+_INS_CLOSE           = 0xB7
+
+_CURVE = SECP256K1()
+SUPPORTED_SECURE_CHANNEL_MODES = ("ss", "es", "ee")
+
+
+def _parse_pubkey(data: bytes) -> EllipticCurvePublicKey:
+    """Parse a 33- or 65-byte serialized secp256k1 public key."""
+    return EllipticCurvePublicKey.from_encoded_point(_CURVE, data)
+
+
+def _serialize_pubkey(pub: EllipticCurvePublicKey, compressed: bool = False) -> bytes:
+    fmt = PublicFormat.CompressedPoint if compressed else PublicFormat.UncompressedPoint
+    return pub.public_bytes(Encoding.X962, fmt)
+
+
+def _ecdh(private_key, peer_pubkey: EllipticCurvePublicKey) -> bytes:
+    """Return the 32-byte x-coordinate of the ECDH shared point."""
+    return private_key.exchange(ECDH(), peer_pubkey)
+
+
+def _verify_sig(pub: EllipticCurvePublicKey, sig_der: bytes, msg_hash: bytes) -> bool:
+    """Verify a DER-encoded ECDSA signature over a pre-computed SHA-256 hash."""
+    try:
+        pub.verify(sig_der, msg_hash, ECDSA(Prehashed(SHA256())))
+        return True
+    except InvalidSignature:
+        return False
+
+
+class SecureError(Exception):
+    """Raised when the card returns a non-9000 code inside the secure channel."""
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(f"Secure channel error: {code}")
+
+
+class SecureChannel:
+    """
+    Encrypted and authenticated channel to an applet derived from SecureApplet.
+
+    Parameters
+    ----------
+    card :
+        A :class:`~specter_card.connection.Card` or
+        :class:`~specter_card.connection.Simulator` instance.
+    mode : str
+        ``"ss"``, ``"es"`` (default), or ``"ee"``.
+    """
+
+    def __init__(self, card, mode: str = "es"):
+        self.card = card
+        self.mode = mode
+        self.iv = 0
+        self.is_open = False
+        self._host_static_private_key = None
+        self._card_pubkey = None
+        self._card_aes_key = None
+        self._host_aes_key = None
+        self._card_mac_key = None
+        self._host_mac_key = None
+
+    # ------------------------------------------------------------------
+    # Key-exchange helpers
+    # ------------------------------------------------------------------
+    def _get_card_pubkey(self):
+        sec = self.card.request(bytes([_CLA, _INS_GET_PUBKEY, 0x00, 0x00]))
+        self._card_pubkey = _parse_pubkey(sec)
+        return self._card_pubkey
+
+    def _derive_keys(self, shared_secret: bytes):
+        self._host_aes_key = hashlib.sha256(b"host_aes" + shared_secret).digest()
+        self._card_aes_key = hashlib.sha256(b"card_aes" + shared_secret).digest()
+        self._host_mac_key = hashlib.sha256(b"host_mac" + shared_secret).digest()
+        self._card_mac_key = hashlib.sha256(b"card_mac" + shared_secret).digest()
+
+    # ------------------------------------------------------------------
+    # Open / close
+    # ------------------------------------------------------------------
+    def open(self, mode: str = None):
+        """Establish the secure channel."""
+        if mode is not None:
+            self.mode = mode
+        if self.mode not in SUPPORTED_SECURE_CHANNEL_MODES:
+            raise ValueError(
+                f"Unsupported secure channel mode: {self.mode!r}. "
+                f"Expected one of {SUPPORTED_SECURE_CHANNEL_MODES!r}"
+            )
+
+        if self._card_pubkey is None:
+            self._get_card_pubkey()
+
+        if self.mode == "ss":
+            if self._host_static_private_key is None:
+                self._host_static_private_key = derive_private_key(
+                    int.from_bytes(os.urandom(32), "big"), _CURVE
+                )
+            host_nonce = os.urandom(32)
+            host_pub_bytes = _serialize_pubkey(self._host_static_private_key.public_key())
+            res = self.card.request(
+                bytes([_CLA, _INS_OPEN_SS, 0x00, 0x00]) + _encode(host_pub_bytes + host_nonce)
+            )
+            s = BytesIO(res)
+            nonce_card = s.read(32)
+            recv_hmac = s.read(HMAC_LEN)
+            shared_x = _ecdh(self._host_static_private_key, self._card_pubkey)
+            secret_with_nonces = hashlib.sha256(shared_x + host_nonce + nonce_card).digest()
+            self._derive_keys(secret_with_nonces)
+            h = hmac.new(self._card_mac_key, nonce_card, digestmod="sha256")
+            if h.digest()[:HMAC_LEN] != recv_hmac:
+                raise RuntimeError("HMAC mismatch during SS channel open")
+            data_signed = nonce_card + recv_hmac
+            raw_sig = s.read()
+            if not _verify_sig(self._card_pubkey, raw_sig, hashlib.sha256(data_signed).digest()):
+                raise RuntimeError("Invalid card signature during SS channel open")
+        elif self.mode == "ee":
+            host_prv = derive_private_key(int.from_bytes(os.urandom(32), "big"), _CURVE)
+            host_pub_bytes = _serialize_pubkey(host_prv.public_key())
+            res = self.card.request(
+                bytes([_CLA, _INS_OPEN_EE, 0x00, 0x00]) + _encode(host_pub_bytes)
+            )
+            s = BytesIO(res)
+            card_pub_bytes = s.read(65)
+            card_ephemeral_pub = _parse_pubkey(card_pub_bytes)
+            shared_x = _ecdh(host_prv, card_ephemeral_pub)
+            shared_secret = hashlib.sha256(shared_x).digest()
+            self._derive_keys(shared_secret)
+            recv_hmac = s.read(HMAC_LEN)
+            h = hmac.new(self._card_mac_key, card_pub_bytes, digestmod="sha256")
+            if h.digest()[:HMAC_LEN] != recv_hmac:
+                raise RuntimeError("HMAC mismatch during EE channel open")
+            # verify card signature
+            data_signed = card_pub_bytes + recv_hmac
+            raw_sig = s.read()
+            if not _verify_sig(self._card_pubkey, raw_sig, hashlib.sha256(data_signed).digest()):
+                raise RuntimeError("Invalid card signature during EE channel open")
+        elif self.mode == "es":
+            # es mode (default)
+            host_prv = derive_private_key(int.from_bytes(os.urandom(32), "big"), _CURVE)
+            host_pub_bytes = _serialize_pubkey(host_prv.public_key())
+            res = self.card.request(
+                bytes([_CLA, _INS_OPEN_SE, 0x00, 0x00]) + _encode(host_pub_bytes)
+            )
+            s = BytesIO(res)
+            nonce_card = s.read(32)
+            recv_hmac = s.read(HMAC_LEN)
+            shared_x = _ecdh(host_prv, self._card_pubkey)
+            secret_with_nonce = hashlib.sha256(shared_x + nonce_card).digest()
+            self._derive_keys(secret_with_nonce)
+            h = hmac.new(self._card_mac_key, nonce_card, digestmod="sha256")
+            if h.digest()[:HMAC_LEN] != recv_hmac:
+                raise RuntimeError("HMAC mismatch during ES channel open")
+            data_signed = nonce_card + recv_hmac
+            raw_sig = s.read()
+            if not _verify_sig(self._card_pubkey, raw_sig, hashlib.sha256(data_signed).digest()):
+                raise RuntimeError("Invalid card signature during ES channel open")
+
+        self.iv = 0
+        self.is_open = True
+
+    def close(self):
+        """Ask the card to close the channel and mark it as closed locally."""
+        self.card.request(bytes([_CLA, _INS_CLOSE, 0x00, 0x00]))
+        self.is_open = False
+
+    # ------------------------------------------------------------------
+    # Encrypt / decrypt
+    # ------------------------------------------------------------------
+    def _encrypt(self, data: bytes) -> bytes:
+        d = data + b"\x80"
+        if len(d) % 16:
+            d += b"\x00" * (16 - len(d) % 16)
+        iv = self.iv.to_bytes(16, "big")
+        cipher = Cipher(algorithms.AES(self._host_aes_key), modes.CBC(iv))
+        enc = cipher.encryptor()
+        ct = enc.update(d) + enc.finalize()
+        h = hmac.new(self._host_mac_key, iv + ct, digestmod="sha256")
+        return ct + h.digest()[:HMAC_LEN]
+
+    def _decrypt(self, ct: bytes) -> bytes:
+        recv_hmac = ct[-HMAC_LEN:]
+        ct = ct[:-HMAC_LEN]
+        iv = self.iv.to_bytes(16, "big")
+        h = hmac.new(self._card_mac_key, iv + ct, digestmod="sha256")
+        if h.digest()[:HMAC_LEN] != recv_hmac:
+            raise RuntimeError("HMAC mismatch in card response")
+        cipher = Cipher(algorithms.AES(self._card_aes_key), modes.CBC(iv))
+        dec = cipher.decryptor()
+        plain = dec.update(ct) + dec.finalize()
+        pad_start = plain.rfind(b"\x80")
+        if pad_start == -1 or plain[pad_start + 1:].replace(b"\x00", b""):
+            raise RuntimeError("Invalid M2 padding in card response")
+        return plain[:pad_start]
+
+    # ------------------------------------------------------------------
+    # Send / receive over secure channel
+    # ------------------------------------------------------------------
+    def request(self, data: bytes) -> bytes:
+        """
+        Send *data* encrypted over the secure channel.
+
+        Automatically re-opens the channel if iv wraps or the channel is closed.
+        Raises :exc:`SecureError` if the card returns a non-9000 status inside
+        the encrypted envelope.
+        """
+        if self.iv >= MAX_IV or not self.is_open:
+            self.open()
+        ct = self._encrypt(data)
+        res = self.card.request(
+            bytes([_CLA, _INS_SECURE_MESSAGE, 0x00, 0x00]) + _encode(ct)
+        )
+        plaintext = self._decrypt(res)
+        self.iv += 1
+        if plaintext[:2] == b"\x90\x00":
+            return plaintext[2:]
+        raise SecureError(plaintext[:2].hex())

--- a/tests/tests/test_securechannel_modes.py
+++ b/tests/tests/test_securechannel_modes.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+import hashlib
+import hmac
+import sys
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    ECDH,
+    ECDSA,
+    SECP256K1,
+    EllipticCurvePublicKey,
+    derive_private_key,
+)
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "py"))
+
+from specter_card.cli import _open_sc
+from specter_card.securechannel import HMAC_LEN, SUPPORTED_SECURE_CHANNEL_MODES, SecureChannel
+
+EXPECTED_SECURE_RANDOM = bytes(reversed(range(32)))
+
+
+def _serialize_pubkey(pub):
+    return pub.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+
+
+def _parse_pubkey(data):
+    return EllipticCurvePublicKey.from_encoded_point(SECP256K1(), data)
+
+
+def _ecdh(private_key, peer_pubkey):
+    return private_key.exchange(ECDH(), peer_pubkey)
+
+
+def _pad(data):
+    data += b"\x80"
+    if len(data) % 16:
+        data += b"\x00" * (16 - len(data) % 16)
+    return data
+
+
+def _unpad(data):
+    pad_start = data.rfind(b"\x80")
+    if pad_start == -1 or data[pad_start + 1:].replace(b"\x00", b""):
+        raise RuntimeError("Invalid M2 padding")
+    return data[:pad_start]
+
+
+def _derive_keys(secret):
+    return {
+        "host_aes": hashlib.sha256(b"host_aes" + secret).digest(),
+        "card_aes": hashlib.sha256(b"card_aes" + secret).digest(),
+        "host_mac": hashlib.sha256(b"host_mac" + secret).digest(),
+        "card_mac": hashlib.sha256(b"card_mac" + secret).digest(),
+    }
+
+
+class FakeSecureAppletCard:
+    def __init__(self, fail_open_modes=None):
+        self._curve = SECP256K1()
+        self._static_private_key = derive_private_key(7, self._curve)
+        self._iv = 0
+        self._keys = None
+        self._is_open = False
+        self._fail_open_modes = set(fail_open_modes or ())
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    def connect(self):
+        self.connect_calls += 1
+
+    def disconnect(self):
+        self.disconnect_calls += 1
+        self._is_open = False
+        self._keys = None
+
+    def request(self, apdu: bytes) -> bytes:
+        cla, ins = apdu[0], apdu[1]
+        if cla != 0xB0:
+            raise RuntimeError(f"Unsupported CLA: {cla:02x}")
+        payload = apdu[5:] if len(apdu) > 4 else b""
+
+        if ins == 0xB2:
+            return _serialize_pubkey(self._static_private_key.public_key())
+        if ins == 0xB3:
+            if "ss" in self._fail_open_modes:
+                raise RuntimeError("ss mode failed")
+            return self._open_ss(payload)
+        if ins == 0xB4:
+            if "es" in self._fail_open_modes:
+                raise RuntimeError("es mode failed")
+            return self._open_es(payload)
+        if ins == 0xB5:
+            if "ee" in self._fail_open_modes:
+                raise RuntimeError("ee mode failed")
+            return self._open_ee(payload)
+        if ins == 0xB6:
+            return self._secure_message(payload)
+        if ins == 0xB7:
+            self._is_open = False
+            return b""
+        raise RuntimeError(f"Unsupported INS: {ins:02x}")
+
+    def _sign(self, data):
+        digest = hashlib.sha256(data).digest()
+        return self._static_private_key.sign(digest, ECDSA(Prehashed(SHA256())))
+
+    def _open_ss(self, payload):
+        host_pub = _parse_pubkey(payload[:65])
+        host_nonce = payload[65:]
+        card_nonce = bytes(range(32))
+        shared_x = _ecdh(self._static_private_key, host_pub)
+        secret = hashlib.sha256(shared_x + host_nonce + card_nonce).digest()
+        self._keys = _derive_keys(secret)
+        self._iv = 0
+        self._is_open = True
+        response = card_nonce
+        response += hmac.new(self._keys["card_mac"], card_nonce, digestmod="sha256").digest()[:HMAC_LEN]
+        return response + self._sign(response)
+
+    def _open_es(self, payload):
+        host_pub = _parse_pubkey(payload)
+        card_nonce = bytes(range(32, 64))
+        shared_x = _ecdh(self._static_private_key, host_pub)
+        secret = hashlib.sha256(shared_x + card_nonce).digest()
+        self._keys = _derive_keys(secret)
+        self._iv = 0
+        self._is_open = True
+        response = card_nonce
+        response += hmac.new(self._keys["card_mac"], card_nonce, digestmod="sha256").digest()[:HMAC_LEN]
+        return response + self._sign(response)
+
+    def _open_ee(self, payload):
+        host_pub = _parse_pubkey(payload)
+        ephemeral_private = derive_private_key(11, self._curve)
+        card_pub = _serialize_pubkey(ephemeral_private.public_key())
+        shared_x = _ecdh(ephemeral_private, host_pub)
+        secret = hashlib.sha256(shared_x).digest()
+        self._keys = _derive_keys(secret)
+        self._iv = 0
+        self._is_open = True
+        response = card_pub
+        response += hmac.new(self._keys["card_mac"], card_pub, digestmod="sha256").digest()[:HMAC_LEN]
+        return response + self._sign(response)
+
+    def _secure_message(self, payload):
+        if not self._is_open:
+            raise RuntimeError("Secure channel not open")
+
+        iv = self._iv.to_bytes(16, "big")
+        recv_hmac = payload[-HMAC_LEN:]
+        ciphertext = payload[:-HMAC_LEN]
+        expected_hmac = hmac.new(
+            self._keys["host_mac"], iv + ciphertext, digestmod="sha256"
+        ).digest()[:HMAC_LEN]
+        if recv_hmac != expected_hmac:
+            raise RuntimeError("Host MAC mismatch")
+
+        decryptor = Cipher(algorithms.AES(self._keys["host_aes"]), modes.CBC(iv)).decryptor()
+        command = _unpad(decryptor.update(ciphertext) + decryptor.finalize())
+
+        if command == b"\x01\x00":
+            response_plain = b"\x90\x00" + EXPECTED_SECURE_RANDOM
+        elif command.startswith(b"\x00\x00"):
+            response_plain = b"\x90\x00" + command[2:]
+        else:
+            raise RuntimeError(f"Unsupported secure command: {command.hex()}")
+
+        encryptor = Cipher(algorithms.AES(self._keys["card_aes"]), modes.CBC(iv)).encryptor()
+        response_ciphertext = encryptor.update(_pad(response_plain)) + encryptor.finalize()
+        response_hmac = hmac.new(
+            self._keys["card_mac"], iv + response_ciphertext, digestmod="sha256"
+        ).digest()[:HMAC_LEN]
+        self._iv += 1
+        return response_ciphertext + response_hmac
+
+
+class SecureChannelModesTest(unittest.TestCase):
+    def test_all_modes_secure_random(self):
+        for mode in SUPPORTED_SECURE_CHANNEL_MODES:
+            with self.subTest(mode=mode):
+                card = FakeSecureAppletCard()
+                sc = SecureChannel(card, mode=mode)
+                sc.open()
+                self.assertEqual(sc.request(b"\x01\x00"), EXPECTED_SECURE_RANDOM)
+                self.assertEqual(sc.is_open, True)
+
+    def test_auto_mode_prefers_ee(self):
+        card = FakeSecureAppletCard()
+        sc = _open_sc(card, mode="auto")
+        self.assertEqual(sc.mode, "ee")
+        self.assertEqual(card.working_secure_channel_mode, "ee")
+        sc.close()
+
+    def test_auto_mode_falls_back_to_es(self):
+        card = FakeSecureAppletCard(fail_open_modes={"ee"})
+        sc = _open_sc(card, mode="auto")
+        self.assertEqual(sc.mode, "es")
+        self.assertEqual(card.working_secure_channel_mode, "es")
+        self.assertGreaterEqual(card.disconnect_calls, 1)
+        sc.close()
+
+    def test_forced_mode_does_not_fallback(self):
+        card = FakeSecureAppletCard(fail_open_modes={"ee"})
+        with self.assertRaises(RuntimeError):
+            _open_sc(card, mode="ee")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new Python package, `specter-card`, providing both a library and CLI for interacting with Specter JavaCard applets. The changes add the core package structure, CLI launcher, applet interfaces, and supporting documentation, making it possible to install, use, and extend the tool for smartcard operations.

The most important changes are:

**New Python package and CLI:**
* Added `setup.py` for packaging, with `specter-card` as a CLI entry point and dependencies on `cryptography` and `pyscard`. [[1]](diffhunk://#diff-722aeeec2821793eb6adf0c529cc7439c4b27ce78937cbb8840e94d4fc1c4017R1-R23) [[2]](diffhunk://#diff-6aeed0b3fd7a115160945fdabc2be76056d10a8afdea93befd40d1fc05448e7cR1-R2)
* Added a thin launcher script `cli.py` to allow running the CLI directly from source or as an installed package.

**Core library structure and exports:**
* Added `specter_card/__init__.py` and `specter_card/applets/__init__.py` to define the library’s public API and submodules for the various applets. [[1]](diffhunk://#diff-03c1ac339039995ee58a38aaad0b2bfc9132cf57a3f10bf41046275365201745R1-R22) [[2]](diffhunk://#diff-b3c9bdb862d5e24d6acedd2d14a390678952ff5de446d6bb9aee2a551056aa62R1-R15)

**Applet implementations:**
* Implemented high-level interfaces for the `BlindOracleApplet` and `MemoryCardApplet`, supporting BIP-32 key management, signing, and secure data storage, including Specter-DIY blob decryption. [[1]](diffhunk://#diff-cfd8a1213e0a762b98ef3a7dc62fd4191f4c6e7b92647a51653abe84c62da442R1-R211) [[2]](diffhunk://#diff-bbc523234280af34bb3e51d1dc44c38b2b638f4391abe2e11542ae683a0cbc84R1-R92)

**Documentation and usage examples:**
* Added a comprehensive `README.md` covering installation, CLI usage, library examples, and simulator instructions.